### PR TITLE
Add Callback with IServiceProvider arg

### DIFF
--- a/Plugin.RevenueCat/RevenueCatManager.cs
+++ b/Plugin.RevenueCat/RevenueCatManager.cs
@@ -4,9 +4,9 @@ using Plugin.RevenueCat.Models;
 
 namespace Plugin.RevenueCat;
 
-public class CustomerInfoUpdatedEventArgs(CustomerInfo customerInfo) : EventArgs
+public class CustomerInfoUpdatedEventArgs(CustomerInfo customerInfoRequest) : EventArgs
 {
-	public CustomerInfo CustomerInfo => customerInfoRequest;
+	public CustomerInfo CustomerInfoRequest => customerInfoRequest;
 }
 
 public class RevenueCatManager : IRevenueCatManager

--- a/Plugin.RevenueCat/RevenueCatManager.cs
+++ b/Plugin.RevenueCat/RevenueCatManager.cs
@@ -4,17 +4,18 @@ using Plugin.RevenueCat.Models;
 
 namespace Plugin.RevenueCat;
 
-public class CustomerInfoUpdatedEventArgs(CustomerInfo customerInfoRequest) : EventArgs
+public class CustomerInfoUpdatedEventArgs(CustomerInfo customerInfo) : EventArgs
 {
-	public CustomerInfo CustomerInfoRequest => customerInfoRequest;
+	public CustomerInfo CustomerInfo => customerInfoRequest;
 }
 
 public class RevenueCatManager : IRevenueCatManager
 {
-	public RevenueCatManager(RevenueCatOptions options, IRevenueCatPlatformImplementation platformImplementation, ILoggerFactory? loggerFactory = null)
+	public RevenueCatManager(RevenueCatOptions options, IRevenueCatPlatformImplementation platformImplementation, IServiceProvider serviceProvider, ILoggerFactory? loggerFactory = null)
 	{
 		Options = options;
 		PlatformImplementation = platformImplementation;
+		ServiceProvider = serviceProvider;
 		Logger = loggerFactory?.CreateLogger<RevenueCatManager>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<RevenueCatManager>.Instance;
 	}
 
@@ -27,26 +28,27 @@ public class RevenueCatManager : IRevenueCatManager
 	public string? ApiKey => PlatformImplementation.ApiKey;
 
 	protected readonly ILogger Logger;
+	protected readonly IServiceProvider ServiceProvider;
 	
 	public void Initialize()
 	{
 		Logger.LogInformation($"RevenueCat->{nameof(Initialize)}: Initializing...");
-		
+
 		PlatformImplementation.SetCustomerInfoUpdatedHandler((json) =>
 		{
 			if (Options.Debug)
 				Logger.LogInformation($"RevenueCat->{nameof(CustomerInfoUpdated)}: Received JSON: {json}");
 
 			Logger.LogInformation($"RevenueCat->{nameof(CustomerInfoUpdated)}: Deserializing JSON...");
-			
+
 			var customerInfoRequest = ParseJson<CustomerInfo>(nameof(Initialize), json);
-			
+
 			if (customerInfoRequest is not null)
 			{
 				Logger.LogInformation($"RevenueCat->{nameof(CustomerInfoUpdated)}: Callback...");
-				
+
 				// Call callback first
-				Options.CustomerInfoUpdatedCallback?.Invoke(customerInfoRequest);
+				Options.CustomerInfoUpdatedCallback?.Invoke(ServiceProvider, customerInfoRequest);
 				// Raise event too
 				CustomerInfoUpdated?.Invoke(this, new CustomerInfoUpdatedEventArgs(customerInfoRequest));
 			}

--- a/Plugin.RevenueCat/RevenueCatOptions.cs
+++ b/Plugin.RevenueCat/RevenueCatOptions.cs
@@ -10,4 +10,4 @@ public record RevenueCatOptions(
 	bool Debug,
 	string? UserId,
 	string? AppStore,
-	Action<CustomerInfo>? CustomerInfoUpdatedCallback);
+	Action<IServiceProvider, CustomerInfo>? CustomerInfoUpdatedCallback);

--- a/Plugin.RevenueCat/RevenueCatOptionsBuilder.cs
+++ b/Plugin.RevenueCat/RevenueCatOptionsBuilder.cs
@@ -106,15 +106,35 @@ public class RevenueCatOptionsBuilder
 		return this;
 	}
 	
-	public Action<CustomerInfo>? CustomerInfoUpdatedCallback { get; set; }
+	public Action<IServiceProvider, CustomerInfo>? CustomerInfoUpdatedCallback { get; set; }
+
 	public RevenueCatOptionsBuilder WithCallback(Action<CustomerInfo>? callback)
 	{
+		if (callback is null)
+		{
+			CustomerInfoUpdatedCallback = null;
+			return this;
+		}
+
+
+		CustomerInfoUpdatedCallback = (s, c) => callback(c);
+		return this;
+	}
+	
+	public RevenueCatOptionsBuilder WithCallback(Action<IServiceProvider, CustomerInfo>? callback)
+	{
+		if (callback is null)
+		{
+			CustomerInfoUpdatedCallback = null;
+			return this;
+		}
+
 		CustomerInfoUpdatedCallback = callback;
 		return this;
 	}
 
 	public RevenueCatOptions Build()
-		=> new (
+		=> new(
 			AndroidApiKey,
 			AmazonApiKey,
 			iOSApiKey,

--- a/sample/MauiProgram.cs
+++ b/sample/MauiProgram.cs
@@ -16,6 +16,11 @@ public static class MauiProgram
 				fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
 			})
 			.UseRevenueCat(o => o
+				.WithCallback((sp, customerInfo) =>
+				{
+					var logger = sp.GetRequiredService<ILogger<RevenueCatManager>>();
+					logger.LogInformation($"Received customer info: {customerInfo}");
+				})
 				.WithAndroidApiKey("goog_[YOUR_GOOGLE_CLIENT_KEY]")
 				.WithAppleApiKey("appl_[YOUR_APPLE_CLIENT_KEY]")
 				.WithDebug(true));


### PR DESCRIPTION
The callback in the `RevenueCatOptions` now have an `IServiceProvider` arg in the `Action` (including a fluent method for setting the callback on the options).