### PR TITLE
Add support for calling Sync Purchases

### DIFF
--- a/Plugin.RevenueCat/IRevenueCatManager.cs
+++ b/Plugin.RevenueCat/IRevenueCatManager.cs
@@ -16,6 +16,8 @@ public interface IRevenueCatManager
 	Task<Offering?> GetOfferingAsync(string offeringIdentifier);
 	
 	Task<CustomerInfo?> RestoreAsync();
+	
+	Task<CustomerInfo?> SyncPurchasesAsync();
 
 	Task<CustomerInfo?> PurchaseAsync(object? platformContext, string offeringIdentifier, string packageIdentifier);
 }

--- a/Plugin.RevenueCat/IRevenueCatPlatformImplementation.cs
+++ b/Plugin.RevenueCat/IRevenueCatPlatformImplementation.cs
@@ -19,4 +19,6 @@ public interface IRevenueCatPlatformImplementation
 	Task<string?> GetOfferingAsync(string offeringIdentifier);
 
 	Task<string?> RestoreAsync();
+	
+	Task<string?> SyncPurchasesAsync();
 }

--- a/Plugin.RevenueCat/Platforms/Android/RevenueCatAndroid.cs
+++ b/Plugin.RevenueCat/Platforms/Android/RevenueCatAndroid.cs
@@ -79,6 +79,12 @@ public class RevenueCatAndroid : Java.Lang.Object, IRevenueCatPlatformImplementa
 		var s = await global::RevenueCat.RevenueCatManager.Restore()!.AsTask<Java.Lang.String>();
 		return s?.ToString();
 	}
+	
+	public async Task<string?> SyncPurchasesAsync()
+	{
+		var s = await global::RevenueCat.RevenueCatManager.SyncPurchases()!.AsTask<Java.Lang.String>();
+		return s?.ToString();
+	}
 
 	public async Task<string?> PurchaseAsync(object? platformContext, string offeringIdentifier, string packageIdentifier)
 	{

--- a/Plugin.RevenueCat/Platforms/MacCatalyst/RevenueCatApple.cs
+++ b/Plugin.RevenueCat/Platforms/MacCatalyst/RevenueCatApple.cs
@@ -42,6 +42,12 @@ public class RevenueCatApple : IRevenueCatPlatformImplementation
         return s.ToString();
     }
 
+    public async Task<string?> SyncPurchasesAsync()
+    {
+	    var s = await revenueCatManager.SyncPurchasesAsync();
+	    return s.ToString();
+    }
+    
     public async Task<string?> PurchaseAsync(object? platformContext, string offeringIdentifier, string packageIdentifier)
     {
         var s = await revenueCatManager.PurchaseAsync(new NSString(offeringIdentifier), new NSString(packageIdentifier));

--- a/Plugin.RevenueCat/Platforms/iOS/RevenueCatApple.cs
+++ b/Plugin.RevenueCat/Platforms/iOS/RevenueCatApple.cs
@@ -43,6 +43,12 @@ public class RevenueCatApple : IRevenueCatPlatformImplementation
         var s = await revenueCatManager.RestoreAsync();
         return s.ToString();
     }
+    
+    public async Task<string?> SyncPurchasesAsync()
+    {
+	    var s = await revenueCatManager.SyncPurchasesAsync();
+	    return s.ToString();
+    }
 
     public async Task<string?> PurchaseAsync(object? platformContext, string offeringIdentifier, string packageIdentifier)
     {

--- a/Plugin.RevenueCat/RevenueCatManager.cs
+++ b/Plugin.RevenueCat/RevenueCatManager.cs
@@ -74,6 +74,9 @@ public class RevenueCatManager : IRevenueCatManager
 
 	public Task<CustomerInfo?> RestoreAsync()
 		=> Request<CustomerInfo>(nameof(RestoreAsync), PlatformImplementation.RestoreAsync);
+	
+	public Task<CustomerInfo?> SyncPurchasesAsync()
+		=> Request<CustomerInfo>(nameof(SyncPurchasesAsync), PlatformImplementation.SyncPurchasesAsync);
 
 	public Task<CustomerInfo?> PurchaseAsync(object? platformContext, string offeringIdentifier, string packageIdentifier)
 		=> Request<CustomerInfo>(nameof(PurchaseAsync), () => PlatformImplementation.PurchaseAsync(platformContext, offeringIdentifier, packageIdentifier));

--- a/android/native/revenuecatbinding/src/main/java/com/revenuecat/revenuecatbinding/RevenueCatManager.java
+++ b/android/native/revenuecatbinding/src/main/java/com/revenuecat/revenuecatbinding/RevenueCatManager.java
@@ -23,6 +23,7 @@ import com.revenuecat.purchases.interfaces.LogInCallback;
 import com.revenuecat.purchases.interfaces.PurchaseCallback;
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback;
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback;
+import com.revenuecat.purchases.interfaces.SyncPurchasesCallback;
 import com.revenuecat.purchases.models.StoreProduct;
 import com.revenuecat.purchases.models.StoreTransaction;
 import com.revenuecat.purchases.models.Period;
@@ -252,6 +253,26 @@ public class RevenueCatManager
 
         return future;
     }
+
+	public static CompletableFuture<String> syncPurchases()
+	{
+		CompletableFuture<String> future = new CompletableFuture<>();
+
+		Purchases.getSharedInstance().syncPurchases(new SyncPurchasesCallback() {
+			@Override
+			public void onSuccess(@NonNull CustomerInfo customerInfo) {
+				handleCustomerInfoUpdated(customerInfo);
+				future.complete(customerInfo.getRawData().toString());
+			}
+
+			@Override
+			public void onError(@NonNull PurchasesError purchasesError) {
+				future.completeExceptionally(new Exception(purchasesError.getMessage()));
+			}
+		});
+
+		return future;
+	}
 
 
     static CustomerInfoUpdatedListener customerInfoUpdatedListener;

--- a/macios/RevenueCat.MaciOS.Binding/ApiDefinition.cs
+++ b/macios/RevenueCat.MaciOS.Binding/ApiDefinition.cs
@@ -31,6 +31,10 @@ namespace RevenueCat
 		[Async]
 		void Restore(System.Action<NSString?, NSError?> callback);
 		
+		[Export("syncPurchases:")]
+		[Async]
+		void SyncPurchases(System.Action<NSString?, NSError?> callback);
+		
 		// Purchase method
 		[Export("purchase:packageIdentifier:callback:")]
 		[Async]

--- a/macios/native/RevenueCatBinding/RevenueCatBinding/RevenueCatBinding.swift
+++ b/macios/native/RevenueCatBinding/RevenueCatBinding/RevenueCatBinding.swift
@@ -53,6 +53,13 @@ public class RevenueCatManager : NSObject
             self.processCustomerInfo(customerInfo: customerInfo, originalError: error, callback: callback)
         }
     }
+	
+	@objc(syncPurchases:)
+	public func syncPurchases(callback: @escaping (NSString?, NSError?) -> Void) {
+		Purchases.shared.syncPurchases() { (customerInfo, error) in
+			self.processCustomerInfo(customerInfo: customerInfo, originalError: error, callback: callback)
+		}
+	}
 
     @objc(getOffering:callback:)
     public func getOffering(offeringId: String, callback: @escaping (NSString?, NSError?) -> Void) {


### PR DESCRIPTION
This method is to be used when trying to synchronize store purchases in the background to avoid user prompts.  Mostly used for migration purposes.