### PR TITLE
Native SDK Updates + AI Skills/Instructions

### DIFF
--- a/.claude/skills/android-slim-bindings/SKILL.md
+++ b/.claude/skills/android-slim-bindings/SKILL.md
@@ -1,0 +1,1660 @@
+---
+name: android-slim-bindings
+description: Create and update slim/native platform interop bindings for Android in .NET MAUI and .NET for Android projects. Guides through creating Java/Kotlin wrappers, configuring Gradle projects, resolving Maven dependencies, generating C# bindings, and integrating native Android libraries using the Native Library Interop (NLI) approach. Use when asked about Android bindings, AAR/JAR integration, Kotlin interop, Maven dependencies, or bridging native Android SDKs to .NET.
+---
+
+# When to use this skill
+
+Activate this skill when the user asks:
+- How do I create Android bindings for a native library?
+- How do I wrap an Android SDK for use in .NET MAUI?
+- How do I create slim bindings for Android?
+- How do I use Native Library Interop for Android?
+- How do I bind a Kotlin library to .NET?
+- How do I bind a Java library to .NET?
+- How do I integrate an AAR or JAR into .NET MAUI?
+- How do I create a Java/Kotlin wrapper for a native Android library?
+- How do I update Android bindings when the native SDK changes?
+- How do I fix Android binding build errors?
+- How do I expose native Android APIs to C#?
+- How do I resolve Maven dependencies for Android bindings?
+- How do I handle AndroidX dependencies in bindings?
+- How do I fix "Java dependency is not satisfied" errors?
+- How do I use AndroidMavenLibrary in my binding project?
+
+# Overview
+
+This skill guides the creation of **Native Library Interop (Slim Bindings)** for Android. This modern approach creates a thin native Java/Kotlin wrapper exposing only the APIs you need from a native Android library, making bindings easier to create and maintain.
+
+## When to Use Slim Bindings vs Traditional Bindings
+
+| Scenario | Recommended Approach |
+|----------|---------------------|
+| Need only a subset of library functionality | **Slim Bindings** ✓ |
+| Easier maintenance when SDK updates | **Slim Bindings** ✓ |
+| Prefer working in Java/Kotlin for wrapper | **Slim Bindings** ✓ |
+| Better isolation from breaking changes | **Slim Bindings** ✓ |
+| Complex libraries with many dependencies | **Slim Bindings** ✓ |
+| Need entire library API surface | Traditional Bindings |
+| Creating bindings for third-party developers | Traditional Bindings |
+| Already maintaining traditional bindings | Traditional Bindings |
+
+# Inputs
+
+| Parameter | Required | Example | Notes |
+|-----------|----------|---------|-------|
+| libraryName | yes | `FirebaseMessaging`, `OkHttp` | Name of the native Android library to bind |
+| bindingProjectName | yes | `MyBinding.Android` | Name for the C# binding project |
+| dependencySource | no | `maven`, `aar`, `jar` | How the native library is distributed |
+| targetFrameworks | no | `net9.0-android` | Target frameworks (default: latest .NET Android) |
+| exposedApis | no | List of specific APIs | Which native APIs to expose (helps scope the wrapper) |
+| mavenCoordinates | no | `com.example:library:1.0.0` | Maven coordinates if library is from Maven repository |
+
+# Project Structure
+
+The recommended project structure for Native Library Interop:
+
+```
+MyBinding/
+├── android/
+│   ├── native/                              # Android Studio/Gradle project
+│   │   ├── app/
+│   │   │   ├── src/main/
+│   │   │   │   └── java/com/example/mybinding/
+│   │   │   │       └── DotnetMyBinding.java  # Java wrapper implementation
+│   │   │   │   └── kotlin/com/example/mybinding/
+│   │   │   │       └── DotnetMyBinding.kt    # Or Kotlin wrapper
+│   │   │   └── build.gradle.kts
+│   │   ├── settings.gradle.kts
+│   │   └── build.gradle.kts
+│   └── MyBinding.Android.Binding/
+│       ├── MyBinding.Android.Binding.csproj
+│       └── Transforms/
+│           └── Metadata.xml
+├── sample/
+│   └── MauiSample/                          # Sample MAUI app
+│       ├── MauiSample.csproj
+│       └── MainPage.xaml.cs
+└── README.md
+```
+
+# Step-by-step Process
+
+## Step 1: Analyze Dependencies First
+
+Before creating any bindings, analyze the complete dependency tree of your target library. This is the most critical step and where most binding projects fail.
+
+### Prerequisites
+
+Ensure you have:
+- JDK 17+
+- Android SDK with `ANDROID_HOME` environment variable set
+- .NET SDK 9+ (recommended for Java Dependency Verification)
+
+> **Note:** You don't need Gradle installed globally—we'll use the Gradle Wrapper which downloads the correct version automatically.
+
+## Step 2: Create the Android Library Project
+
+There are multiple approaches to create the native Android wrapper project. Choose the one that best fits your workflow.
+
+### Option A: Use Android Studio (Recommended for GUI)
+
+The most reliable way to create a properly configured Android library:
+
+1. **Open Android Studio**
+2. **File → New → New Project**
+3. Select **"No Activity"** template
+4. Configure:
+   - Name: `MyBindingNative`
+   - Package name: `com.example.mybinding`
+   - Language: Java or Kotlin
+   - Minimum SDK: API 21
+5. **File → New → New Module**
+6. Select **"Android Library"**
+7. Name it `app` (or your preferred module name)
+
+This creates a properly structured project with the latest Gradle plugin versions.
+
+### Option B: Use `gradle init` with Wrapper (CLI)
+
+Use Gradle's built-in initialization to scaffold a project, then convert it to Android:
+
+```bash
+# Set your binding name
+BINDING_NAME="MyBinding"
+PACKAGE_NAME="com.example.mybinding"
+
+# Create directory structure
+mkdir -p ${BINDING_NAME}/android/native
+mkdir -p ${BINDING_NAME}/android/${BINDING_NAME}.Android.Binding/Transforms
+mkdir -p ${BINDING_NAME}/sample/MauiSample
+
+cd ${BINDING_NAME}/android/native
+
+# Download and use Gradle wrapper (no global Gradle install needed)
+# This downloads gradle-wrapper.jar and creates gradlew scripts
+curl -sL https://services.gradle.org/distributions/gradle-9.2.1-bin.zip -o gradle.zip
+unzip -q gradle.zip
+./gradle-9.2.1/bin/gradle wrapper --gradle-version 9.2.1
+rm -rf gradle.zip gradle-9.2.1
+
+# Initialize a basic Kotlin library project
+./gradlew init --type kotlin-library --dsl kotlin --project-name ${BINDING_NAME}Native --package ${PACKAGE_NAME} --no-split-project --java-version 17
+
+# The project needs to be converted to Android Library (see next section)
+```
+
+> **Note:** `gradle init` creates a standard JVM library, not an Android library. You'll need to modify the generated files to add Android support (see "Converting to Android Library" below).
+
+### Option C: Clone from Template Repository
+
+Use the Community Toolkit template as a starting point:
+
+```bash
+BINDING_NAME="MyBinding"
+
+# Clone the template
+git clone https://github.com/AdrianSimionescu/NativeLibraryInterop-Template.git ${BINDING_NAME}
+cd ${BINDING_NAME}
+
+# Or use the official CommunityToolkit repo structure
+git clone --depth 1 https://github.com/AdrianSimionescu/NativeLibraryInterop-Template.git ${BINDING_NAME}
+
+# Rename files and references
+find . -type f -name "*.gradle*" -exec sed -i '' 's/TemplateBinding/'"${BINDING_NAME}"'/g' {} \;
+```
+
+### Option D: Manual Creation with Gradle Wrapper
+
+For full control, create the project structure manually but use proper Gradle wrapper initialization:
+
+```bash
+BINDING_NAME="MyBinding"
+PACKAGE_NAME="com.example.mybinding"
+PACKAGE_PATH="${PACKAGE_NAME//./\/}"
+
+# Create directory structure
+mkdir -p ${BINDING_NAME}/android/native/app/src/main/java/${PACKAGE_PATH}
+mkdir -p ${BINDING_NAME}/android/${BINDING_NAME}.Android.Binding/Transforms
+mkdir -p ${BINDING_NAME}/sample/MauiSample
+
+cd ${BINDING_NAME}/android/native
+
+# Create Gradle wrapper (downloads correct Gradle version automatically)
+# Using gradle wrapper from a temporary init
+mkdir -p tmp && cd tmp
+curl -sL https://services.gradle.org/distributions/gradle-9.2.1-bin.zip -o gradle.zip
+unzip -q gradle.zip && ./gradle-9.2.1/bin/gradle wrapper --gradle-version 9.2.1
+mv gradlew gradlew.bat gradle ../ && cd .. && rm -rf tmp
+
+# Now create the project files (see below)
+```
+
+### Creating Gradle Build Files
+
+After setting up the wrapper, create the build files. These files define the project structure and can be version-controlled:
+
+**settings.gradle.kts:**
+
+```kotlin
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        // Add custom repositories as needed
+        // maven { url = uri("https://jitpack.io") }
+    }
+}
+
+rootProject.name = "MyBindingNative"
+include(":app")
+```
+
+**build.gradle.kts (root):**
+
+```kotlin
+plugins {
+    // Use version catalog or explicit versions
+    // Check latest versions at: https://developer.android.com/build/releases/gradle-plugin
+    id("com.android.library") version "8.2.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+}
+```
+
+**app/build.gradle.kts:**
+
+```kotlin
+plugins {
+    id("com.android.library")
+    // Include kotlin plugin only if using Kotlin
+    // id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.mybinding"
+    
+    // Check latest SDK versions: https://developer.android.com/about/versions
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 21
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    
+    // Only needed if using Kotlin
+    // kotlinOptions {
+    //     jvmTarget = "17"
+    // }
+}
+
+dependencies {
+    // Add the native library you want to wrap
+    // implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    
+    // Common dependencies (only add what you need)
+    // implementation("androidx.core:core-ktx:1.12.0")
+}
+```
+
+### Checking for Latest Versions
+
+Always use current versions for Gradle plugins and dependencies:
+
+```bash
+# Check latest Android Gradle Plugin version
+curl -s "https://maven.google.com/web/index.html" | grep -o 'com.android.tools.build:gradle:[0-9.]*' | head -1
+
+# Or check the release notes
+open "https://developer.android.com/build/releases/gradle-plugin"
+
+# Check latest Kotlin version
+curl -s "https://api.github.com/repos/JetBrains/kotlin/releases/latest" | grep '"tag_name"' | cut -d'"' -f4
+```
+
+## Step 3: Analyze the Full Dependency Tree
+
+Add your target library to the dependencies and run:
+
+```bash
+# Get full dependency tree
+./gradlew app:dependencies --configuration releaseRuntimeClasspath
+
+# Get flat list of all dependencies
+./gradlew app:dependencies --configuration releaseRuntimeClasspath | grep -E "^[+\\\\]" | sed 's/.*--- //' | sort -u
+
+# For insight into a specific dependency
+./gradlew app:dependencyInsight --dependency kotlin-stdlib --configuration releaseRuntimeClasspath
+```
+
+**Understanding the output:**
+- `->` indicates version conflict resolution (e.g., `1.9.10 -> 1.9.21`)
+- `(*)` indicates the dependency was already shown elsewhere (deduplication)
+- `(c)` indicates a constraint
+
+### Document Your Dependencies
+
+Create a dependency mapping document:
+
+| Maven Artifact | Version | NuGet Package | Strategy |
+|----------------|---------|---------------|----------|
+| `androidx.core:core` | 1.12.0 | `Xamarin.AndroidX.Core` | NuGet |
+| `org.jetbrains.kotlin:kotlin-stdlib` | 1.9.22 | `Xamarin.Kotlin.StdLib` | NuGet |
+| `com.example:internal-lib` | 1.0.0 | N/A | `Bind="false"` |
+| `org.jetbrains:annotations` | 23.0.0 | N/A | Ignore |
+
+## Step 4: Create the Wrapper Class
+
+Choose Java or Kotlin based on your preference and the native library's language.
+
+### Java Wrapper
+
+Create `app/src/main/java/com/example/mybinding/DotnetMyBinding.java`:
+
+```bash
+mkdir -p app/src/main/java/com/example/mybinding
+
+cat > app/src/main/java/com/example/mybinding/DotnetMyBinding.java << 'EOF'
+package com.example.mybinding;
+
+import android.content.Context;
+import android.util.Log;
+import android.view.View;
+
+/**
+ * Main binding class exposed to .NET
+ * Keep method signatures simple for easy marshalling
+ */
+public class DotnetMyBinding {
+    private static final String TAG = "DotnetMyBinding";
+    private static boolean initialized = false;
+
+    // MARK: - Initialization
+
+    /**
+     * Initialize the native library
+     * Call this from your .NET app's startup
+     */
+    public static void initialize(Context context, boolean debug) {
+        if (initialized) {
+            Log.w(TAG, "Already initialized");
+            return;
+        }
+        
+        // Initialize your native library here
+        // TheNativeLibrary.configure(context, debug);
+        
+        initialized = true;
+        Log.d(TAG, "MyBinding initialized");
+    }
+
+    /**
+     * Check if the library is initialized
+     */
+    public static boolean isInitialized() {
+        return initialized;
+    }
+
+    // MARK: - Synchronous Methods
+
+    /**
+     * Get library version
+     */
+    public static String getVersion() {
+        return "1.0.0";
+    }
+
+    /**
+     * Process data synchronously
+     * @param input The input string to process
+     * @return The processed result, or null on failure
+     */
+    public static String processData(String input) {
+        if (!initialized) {
+            throw new IllegalStateException("Must call initialize() first");
+        }
+        
+        // Process using native library
+        // return TheNativeLibrary.process(input);
+        return "Processed: " + input;
+    }
+
+    // MARK: - Asynchronous Methods (Callback Pattern)
+
+    /**
+     * Callback interface for async operations
+     * .NET will implement this interface
+     */
+    public interface DataCallback {
+        void onSuccess(String result);
+        void onError(String error);
+    }
+
+    /**
+     * Fetch data asynchronously
+     * @param query The query string
+     * @param callback Callback for result/error
+     */
+    public static void fetchDataAsync(String query, final DataCallback callback) {
+        if (!initialized) {
+            callback.onError("Not initialized");
+            return;
+        }
+
+        // Simulate async operation (replace with real native library call)
+        new Thread(() -> {
+            try {
+                Thread.sleep(100); // Simulate network delay
+                String result = "Result for: " + query;
+                callback.onSuccess(result);
+            } catch (Exception e) {
+                callback.onError(e.getMessage());
+            }
+        }).start();
+    }
+
+    /**
+     * Callback with multiple result types
+     */
+    public interface ComplexCallback {
+        void onSuccess(String data, int count, boolean hasMore);
+        void onError(int errorCode, String errorMessage);
+    }
+
+    /**
+     * Complex async operation with multiple callback parameters
+     */
+    public static void performComplexOperation(
+            String input, 
+            int options, 
+            final ComplexCallback callback) {
+        
+        // Perform operation...
+        callback.onSuccess("data", 42, true);
+    }
+
+    // MARK: - View Creation
+
+    /**
+     * Create a native view to embed in .NET MAUI
+     * @param context Android context
+     * @return The native view
+     */
+    public static View createView(Context context) {
+        // Create and return your native view
+        // return new TheNativeLibrary.CustomView(context);
+        
+        View view = new View(context);
+        view.setBackgroundColor(0xFF0066CC);
+        return view;
+    }
+
+    // MARK: - Event Handling
+
+    /**
+     * Event listener interface
+     */
+    public interface EventListener {
+        void onEvent(String eventType, String eventData);
+    }
+
+    private static EventListener eventListener;
+
+    /**
+     * Register an event listener
+     */
+    public static void setEventListener(EventListener listener) {
+        eventListener = listener;
+        
+        // Wire up to native library's events
+        // TheNativeLibrary.setEventHandler(event -> {
+        //     if (eventListener != null) {
+        //         eventListener.onEvent(event.type, event.data);
+        //     }
+        // });
+    }
+
+    /**
+     * Remove the event listener
+     */
+    public static void removeEventListener() {
+        eventListener = null;
+    }
+
+    // MARK: - Configuration
+
+    /**
+     * Set configuration options
+     * Use simple types that marshal easily
+     */
+    public static void configure(
+            String apiKey,
+            String apiSecret,
+            int timeout,
+            boolean enableLogging) {
+        
+        // Apply configuration to native library
+        Log.d(TAG, "Configured with apiKey: " + apiKey);
+    }
+}
+EOF
+```
+
+### Kotlin Wrapper (Alternative)
+
+Create `app/src/main/kotlin/com/example/mybinding/DotnetMyBinding.kt`:
+
+```bash
+mkdir -p app/src/main/kotlin/com/example/mybinding
+
+cat > app/src/main/kotlin/com/example/mybinding/DotnetMyBinding.kt << 'EOF'
+package com.example.mybinding
+
+import android.content.Context
+import android.util.Log
+import android.view.View
+
+/**
+ * Main binding class exposed to .NET
+ * Use @JvmStatic for static method access from C#
+ */
+object DotnetMyBinding {
+    private const val TAG = "DotnetMyBinding"
+    private var initialized = false
+
+    // MARK: - Initialization
+
+    @JvmStatic
+    fun initialize(context: Context, debug: Boolean) {
+        if (initialized) {
+            Log.w(TAG, "Already initialized")
+            return
+        }
+        
+        // Initialize your native library here
+        // TheNativeLibrary.configure(context, debug)
+        
+        initialized = true
+        Log.d(TAG, "MyBinding initialized")
+    }
+
+    @JvmStatic
+    fun isInitialized(): Boolean = initialized
+
+    // MARK: - Synchronous Methods
+
+    @JvmStatic
+    fun getVersion(): String = "1.0.0"
+
+    @JvmStatic
+    fun processData(input: String): String {
+        check(initialized) { "Must call initialize() first" }
+        return "Processed: $input"
+    }
+
+    // MARK: - Asynchronous Methods
+
+    /**
+     * Callback interface - use Java-style interface for better interop
+     */
+    interface DataCallback {
+        fun onSuccess(result: String)
+        fun onError(error: String)
+    }
+
+    @JvmStatic
+    fun fetchDataAsync(query: String, callback: DataCallback) {
+        if (!initialized) {
+            callback.onError("Not initialized")
+            return
+        }
+
+        Thread {
+            try {
+                Thread.sleep(100)
+                callback.onSuccess("Result for: $query")
+            } catch (e: Exception) {
+                callback.onError(e.message ?: "Unknown error")
+            }
+        }.start()
+    }
+
+    // MARK: - View Creation
+
+    @JvmStatic
+    fun createView(context: Context): View {
+        return View(context).apply {
+            setBackgroundColor(0xFF0066CC.toInt())
+        }
+    }
+
+    // MARK: - Event Handling
+
+    interface EventListener {
+        fun onEvent(eventType: String, eventData: String)
+    }
+
+    private var eventListener: EventListener? = null
+
+    @JvmStatic
+    fun setEventListener(listener: EventListener?) {
+        eventListener = listener
+    }
+
+    @JvmStatic
+    fun removeEventListener() {
+        eventListener = null
+    }
+
+    // MARK: - Configuration
+
+    @JvmStatic
+    fun configure(
+        apiKey: String,
+        apiSecret: String,
+        timeout: Int,
+        enableLogging: Boolean
+    ) {
+        Log.d(TAG, "Configured with apiKey: $apiKey")
+    }
+}
+EOF
+```
+
+**Key Points for Kotlin:**
+- Use `@JvmStatic` on all methods for static access from C#
+- Use `object` for singleton pattern (maps to static methods)
+- Use Java-style callback interfaces (not Kotlin lambdas)
+- Avoid coroutines in the public API (use callbacks instead)
+
+### Add Your Native Library Dependency
+
+Update `app/build.gradle.kts` dependencies:
+
+```kotlin
+dependencies {
+    // The native library you're wrapping
+    implementation("com.thirdparty:awesomelib:1.0.0")
+    
+    // Common dependencies
+    implementation("androidx.core:core-ktx:1.12.0")
+}
+```
+
+## Step 5: Build the AAR
+
+```bash
+cd android/native
+
+# Build release AAR
+./gradlew :app:assembleRelease
+
+# The AAR will be at:
+# app/build/outputs/aar/app-release.aar
+```
+
+Verify the AAR contents:
+
+```bash
+unzip -l app/build/outputs/aar/app-release.aar
+```
+
+## Step 6: Create the C# Binding Project
+
+### Create the Binding Project with dotnet new
+
+```bash
+cd ../..  # Back to MyBinding root
+cd android
+
+# Create the binding project using the template
+dotnet new androidbinding -n ${BINDING_NAME}.Android.Binding
+
+cd ${BINDING_NAME}.Android.Binding
+```
+
+This creates a properly structured binding project with:
+- `Transforms/Metadata.xml` - For customizing the generated bindings
+- `Transforms/EnumFields.xml` - For enum mappings (if needed)
+- `Transforms/EnumMethods.xml` - For enum method mappings (if needed)
+
+### Add the AAR Reference
+
+Edit the generated `.csproj` to add your AAR and dependencies:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0-android</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
+  <!-- Your wrapper AAR -->
+  <ItemGroup>
+    <AndroidLibrary Include="../native/app/build/outputs/aar/app-release.aar" />
+  </ItemGroup>
+
+  <!-- Dependencies: NuGet packages for common libraries -->
+  <ItemGroup>
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.12.0.4" />
+    <PackageReference Include="Xamarin.Kotlin.StdLib" Version="1.9.22.1" />
+    
+    <!-- Add more based on your dependency analysis -->
+    <!-- <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.6" /> -->
+  </ItemGroup>
+
+  <!-- Dependencies without NuGet: Include but don't bind -->
+  <ItemGroup>
+    <!-- The library you're wrapping - include but don't generate C# bindings for it -->
+    <!-- <AndroidMavenLibrary Include="com.thirdparty:awesomelib" Version="1.0.0" Bind="false" /> -->
+  </ItemGroup>
+
+  <!-- Compile-time only dependencies to ignore -->
+  <ItemGroup>
+    <AndroidIgnoredJavaDependency Include="org.jetbrains:annotations" Version="*" />
+    <!-- <AndroidIgnoredJavaDependency Include="com.google.errorprone:error_prone_annotations" Version="*" /> -->
+  </ItemGroup>
+</Project>
+```
+
+### Update Metadata.xml
+
+Edit the generated `Transforms/Metadata.xml` to customize the bindings:
+
+```xml
+<metadata>
+  <!-- Rename the Java package to a .NET-friendly namespace -->
+  <attr path="/api/package[@name='com.example.mybinding']" 
+        name="managedName">MyBinding</attr>
+  
+  <!-- Remove obfuscated or internal classes if needed -->
+  <!-- <remove-node path="/api/package[@name='com.example.mybinding']/class[@name='InternalHelper']" /> -->
+  
+  <!-- Rename parameters from p0, p1 to meaningful names -->
+  <attr path="/api/package[@name='com.example.mybinding']/class[@name='DotnetMyBinding']/method[@name='initialize']/parameter[@name='p0']" 
+        name="name">context</attr>
+  <attr path="/api/package[@name='com.example.mybinding']/class[@name='DotnetMyBinding']/method[@name='initialize']/parameter[@name='p1']" 
+        name="name">debug</attr>
+        
+  <attr path="/api/package[@name='com.example.mybinding']/class[@name='DotnetMyBinding']/method[@name='processData']/parameter[@name='p0']" 
+        name="name">input</attr>
+        
+  <attr path="/api/package[@name='com.example.mybinding']/class[@name='DotnetMyBinding']/method[@name='fetchDataAsync']/parameter[@name='p0']" 
+        name="name">query</attr>
+  <attr path="/api/package[@name='com.example.mybinding']/class[@name='DotnetMyBinding']/method[@name='fetchDataAsync']/parameter[@name='p1']" 
+        name="name">callback</attr>
+</metadata>
+```
+
+## Step 7: Resolve Dependencies
+
+This is the critical step. When you build, .NET 9+ will report dependency errors:
+
+```bash
+cd android/${BINDING_NAME}.Android.Binding
+dotnet build
+```
+
+### Understanding Dependency Errors
+
+| Error | Meaning | Solution |
+|-------|---------|----------|
+| **XA4241** | No known NuGet package exists | Use `AndroidMavenLibrary` with `Bind="false"` or `AndroidIgnoredJavaDependency` |
+| **XA4242** | Microsoft maintains a NuGet package | Install the suggested NuGet package |
+
+### Dependency Resolution Decision Tree
+
+```
+For each unsatisfied dependency:
+│
+├─ Is there a XA4242 suggestion?
+│   └─ YES → Install the suggested NuGet package
+│
+├─ Is the dependency needed from C#?
+│   ├─ YES → Find/create a binding NuGet or create your own binding
+│   └─ NO → Use AndroidMavenLibrary with Bind="false"
+│
+├─ Is it a compile-time only dependency (annotations, processors)?
+│   └─ YES → Use AndroidIgnoredJavaDependency
+│
+└─ Otherwise → Create a separate binding project or include AAR/JAR directly
+```
+
+### Finding NuGet Packages for Maven Dependencies
+
+Microsoft-maintained packages include artifact tags. Search by tag:
+
+```bash
+# Search NuGet for a specific Maven artifact
+dotnet package search "artifact=androidx.core:core" --source https://api.nuget.org/v3/index.json
+
+# Or use curl
+curl -s "https://azuresearch-usnc.nuget.org/query?q=tags:artifact=androidx.core:core&take=10" | jq '.data[] | {id: .id, version: .version}'
+```
+
+### Common Maven-to-NuGet Mappings
+
+| Maven Artifact | NuGet Package |
+|----------------|---------------|
+| `androidx.annotation:annotation` | `Xamarin.AndroidX.Annotation` |
+| `androidx.core:core` | `Xamarin.AndroidX.Core` |
+| `androidx.core:core-ktx` | `Xamarin.AndroidX.Core.Core.Ktx` |
+| `androidx.appcompat:appcompat` | `Xamarin.AndroidX.AppCompat` |
+| `androidx.fragment:fragment` | `Xamarin.AndroidX.Fragment` |
+| `androidx.activity:activity` | `Xamarin.AndroidX.Activity` |
+| `androidx.recyclerview:recyclerview` | `Xamarin.AndroidX.RecyclerView` |
+| `androidx.lifecycle:lifecycle-common` | `Xamarin.AndroidX.Lifecycle.Common` |
+| `org.jetbrains.kotlin:kotlin-stdlib` | `Xamarin.Kotlin.StdLib` |
+| `org.jetbrains.kotlinx:kotlinx-coroutines-core` | `Xamarin.KotlinX.Coroutines.Core` |
+| `com.google.android.material:material` | `Xamarin.Google.Android.Material` |
+| `com.squareup.okhttp3:okhttp` | `Square.OkHttp3` |
+| `com.google.code.gson:gson` | `GoogleGson` |
+
+### Practical Example: Complex Library Binding
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0-android</TargetFramework>
+  </PropertyGroup>
+
+  <!-- Your wrapper AAR -->
+  <ItemGroup>
+    <AndroidLibrary Include="../native/app/build/outputs/aar/app-release.aar" />
+  </ItemGroup>
+
+  <!-- Dependencies satisfied by NuGet (preferred) -->
+  <ItemGroup>
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.12.0.4" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.6" />
+    <PackageReference Include="Xamarin.Kotlin.StdLib" Version="1.9.22.1" />
+    <PackageReference Include="Square.OkHttp3" Version="4.12.0.1" />
+  </ItemGroup>
+
+  <!-- The library being wrapped - include but don't bind -->
+  <ItemGroup>
+    <AndroidMavenLibrary 
+      Include="com.thirdparty:awesomelib" 
+      Version="1.0.0" 
+      Bind="false" />
+  </ItemGroup>
+
+  <!-- Dependencies with no NuGet - include but don't bind -->
+  <ItemGroup>
+    <AndroidMavenLibrary 
+      Include="com.thirdparty:internal-util" 
+      Version="1.0.0" 
+      Bind="false" />
+  </ItemGroup>
+
+  <!-- Compile-time only dependencies to ignore -->
+  <ItemGroup>
+    <AndroidIgnoredJavaDependency Include="org.jetbrains:annotations" Version="*" />
+    <AndroidIgnoredJavaDependency Include="com.google.errorprone:error_prone_annotations" Version="*" />
+    <AndroidIgnoredJavaDependency Include="com.google.code.findbugs:jsr305" Version="*" />
+  </ItemGroup>
+</Project>
+```
+
+## Step 8: Customize Bindings with Metadata
+
+### Common Metadata Transforms
+
+#### Rename Java Packages to .NET Namespaces
+
+```xml
+<metadata>
+  <attr path="/api/package[@name='com.example.mybinding']" 
+        name="managedName">MyBinding</attr>
+  <attr path="/api/package[@name='com.example.mybinding.utils']" 
+        name="managedName">MyBinding.Utils</attr>
+</metadata>
+```
+
+#### Rename Classes and Methods
+
+```xml
+<metadata>
+  <!-- Rename a class -->
+  <attr path="/api/package[@name='com.example']/class[@name='Util']" 
+        name="managedName">Utilities</attr>
+  
+  <!-- Rename a method -->
+  <attr path="/api/package[@name='com.example']/class[@name='MyClass']/method[@name='getData']" 
+        name="managedName">GetData</attr>
+</metadata>
+```
+
+#### Rename Parameters
+
+```xml
+<metadata>
+  <!-- Rename p0, p1 to meaningful names -->
+  <attr path="/api/package[@name='com.example']/class[@name='MyClass']/method[@name='process']/parameter[@name='p0']" 
+        name="name">input</attr>
+  <attr path="/api/package[@name='com.example']/class[@name='MyClass']/method[@name='process']/parameter[@name='p1']" 
+        name="name">options</attr>
+</metadata>
+```
+
+#### Remove Internal or Obfuscated Types
+
+```xml
+<metadata>
+  <!-- Remove internal packages -->
+  <remove-node path="/api/package[starts-with(@name, 'com.example.internal')]" />
+  
+  <!-- Remove obfuscated packages -->
+  <remove-node path="/api/package[@name='a']" />
+  <remove-node path="/api/package[@name='b']" />
+  
+  <!-- Remove specific classes -->
+  <remove-node path="/api/package[@name='com.example']/class[@name='InternalHelper']" />
+  
+  <!-- Remove classes with $ (often internal/anonymous) -->
+  <remove-node path="/api/package/class[contains(@name, '$')]" />
+</metadata>
+```
+
+#### Fix Visibility Issues
+
+```xml
+<metadata>
+  <attr path="/api/package[@name='com.example']/class[@name='Helper']" 
+        name="visibility">public</attr>
+</metadata>
+```
+
+### Examining api.xml for XPath Construction
+
+After building, examine the generated API definition:
+
+```bash
+cat obj/Debug/net9.0-android/api.xml
+```
+
+This helps construct the correct XPath for your transforms.
+
+## Step 9: Build and Verify
+
+```bash
+dotnet build -c Release
+```
+
+Check for errors and resolve any remaining dependency issues.
+
+## Step 10: Use in Your MAUI App
+
+### Add Project Reference
+
+In your MAUI app's `.csproj`:
+
+```xml
+<ItemGroup Condition="$(TargetFramework.Contains('android'))">
+  <ProjectReference Include="..\android\MyBinding.Android.Binding\MyBinding.Android.Binding.csproj" />
+</ItemGroup>
+```
+
+### Initialize in MauiProgram.cs
+
+```csharp
+using Microsoft.Maui.Hosting;
+
+#if ANDROID
+using MyBinding;
+#endif
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder.UseMauiApp<App>();
+
+#if ANDROID
+        // Initialize in a platform-specific lifecycle hook
+        builder.ConfigureLifecycleEvents(lifecycle =>
+        {
+            lifecycle.AddAndroid(android =>
+            {
+                android.OnCreate((activity, bundle) =>
+                {
+                    DotnetMyBinding.Initialize(activity, debug: true);
+                });
+            });
+        });
+#endif
+
+        return builder.Build();
+    }
+}
+```
+
+### Implement Callback Interface
+
+```csharp
+#if ANDROID
+using MyBinding;
+using Android.Runtime;
+
+// Implement the callback interface
+public class MyDataCallback : Java.Lang.Object, DotnetMyBinding.IDataCallback
+{
+    private readonly Action<string> _onSuccess;
+    private readonly Action<string> _onError;
+
+    public MyDataCallback(Action<string> onSuccess, Action<string> onError)
+    {
+        _onSuccess = onSuccess;
+        _onError = onError;
+    }
+
+    public void OnSuccess(string result) => _onSuccess(result);
+    public void OnError(string error) => _onError(error);
+}
+#endif
+```
+
+### Use in Your Page
+
+```csharp
+public partial class MainPage : ContentPage
+{
+    public MainPage()
+    {
+        InitializeComponent();
+    }
+
+    private void OnSyncButtonClicked(object sender, EventArgs e)
+    {
+#if ANDROID
+        // Synchronous method
+        var version = DotnetMyBinding.GetVersion();
+        var result = DotnetMyBinding.ProcessData("test input");
+        DisplayAlert("Result", $"Version: {version}\nResult: {result}", "OK");
+#endif
+    }
+
+    private void OnAsyncButtonClicked(object sender, EventArgs e)
+    {
+#if ANDROID
+        // Async with callback
+        DotnetMyBinding.FetchDataAsync("my query", new MyDataCallback(
+            onSuccess: result => MainThread.BeginInvokeOnMainThread(() => 
+                DisplayAlert("Success", result, "OK")),
+            onError: error => MainThread.BeginInvokeOnMainThread(() => 
+                DisplayAlert("Error", error, "OK"))
+        ));
+#endif
+    }
+
+    private void OnCreateViewClicked(object sender, EventArgs e)
+    {
+#if ANDROID
+        var context = Platform.CurrentActivity;
+        var nativeView = DotnetMyBinding.CreateView(context);
+        
+        // Use with a custom handler or Android.Views.View host
+#endif
+    }
+}
+```
+
+### Register Event Listener
+
+```csharp
+#if ANDROID
+public class MyEventListener : Java.Lang.Object, DotnetMyBinding.IEventListener
+{
+    private readonly Action<string, string> _onEvent;
+
+    public MyEventListener(Action<string, string> onEvent)
+    {
+        _onEvent = onEvent;
+    }
+
+    public void OnEvent(string eventType, string eventData)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            _onEvent(eventType, eventData);
+        });
+    }
+}
+
+// In your page
+protected override void OnAppearing()
+{
+    base.OnAppearing();
+    
+#if ANDROID
+    DotnetMyBinding.SetEventListener(new MyEventListener((type, data) =>
+    {
+        StatusLabel.Text = $"Event: {type} - {data}";
+    }));
+#endif
+}
+
+protected override void OnDisappearing()
+{
+    base.OnDisappearing();
+    
+#if ANDROID
+    DotnetMyBinding.RemoveEventListener();
+#endif
+}
+#endif
+```
+
+# Updating Bindings When Native SDK Changes
+
+## Step-by-step Update Process
+
+### 1. Update Native Dependency Version
+
+Edit `app/build.gradle.kts`:
+
+```kotlin
+dependencies {
+    implementation("com.thirdparty:awesomelib:2.0.0")  // Updated version
+}
+```
+
+### 2. Re-analyze Dependencies
+
+```bash
+cd android/native
+./gradlew app:dependencies --configuration releaseRuntimeClasspath
+```
+
+Compare with your previous dependency mapping and identify:
+- New dependencies added
+- Dependencies with version changes
+- Dependencies removed
+
+### 3. Update the Wrapper (If Needed)
+
+Review release notes for the native library and update `DotnetMyBinding.java`:
+- Add new methods for new APIs
+- Update method signatures for changed APIs
+- Remove deprecated API wrappers
+- Handle any breaking changes
+
+### 4. Rebuild the AAR
+
+```bash
+./gradlew :app:assembleRelease
+```
+
+### 5. Update Binding Project Dependencies
+
+Update NuGet packages and Maven dependencies in the binding `.csproj` based on your new dependency analysis.
+
+### 6. Rebuild and Fix Errors
+
+```bash
+cd ../MyBinding.Android.Binding
+dotnet build
+```
+
+Address any new XA4241/XA4242 errors.
+
+### 7. Update Metadata.xml (If Needed)
+
+If new classes/methods were added to your wrapper, update parameter names and namespace mappings.
+
+### 8. Test
+
+Build and run the sample app to verify functionality.
+
+# Handling Native Libraries (.so files)
+
+Some Android libraries include native code (`.so` files). If you get `java.lang.UnsatisfiedLinkError`, ensure native libraries are properly included.
+
+### Including .so Files
+
+For AAR files, `.so` files are usually included automatically. For JAR files, add them manually:
+
+```xml
+<ItemGroup>
+  <AndroidNativeLibrary Include="libs\arm64-v8a\libmynative.so">
+    <Abi>arm64-v8a</Abi>
+  </AndroidNativeLibrary>
+  <AndroidNativeLibrary Include="libs\armeabi-v7a\libmynative.so">
+    <Abi>armeabi-v7a</Abi>
+  </AndroidNativeLibrary>
+  <AndroidNativeLibrary Include="libs\x86_64\libmynative.so">
+    <Abi>x86_64</Abi>
+  </AndroidNativeLibrary>
+</ItemGroup>
+```
+
+### Manually Loading Native Libraries
+
+Sometimes you need to explicitly load the native library:
+
+```csharp
+// In your Android initialization code
+Java.Lang.JavaSystem.LoadLibrary("mynative");
+```
+
+# Troubleshooting
+
+## Build Errors
+
+### "Java dependency 'X' is not satisfied" (XA4241/XA4242)
+
+Missing transitive dependency.
+
+**Solution:** Follow the dependency resolution decision tree:
+1. If XA4242 suggests a NuGet package → Install it
+2. If you don't need the API in C# → Use `AndroidMavenLibrary` with `Bind="false"`
+3. If it's compile-time only → Use `AndroidIgnoredJavaDependency`
+
+### "Type is defined multiple times"
+
+Duplicate classes from including the same dependency twice.
+
+**Solution:** Check for overlap between NuGet packages and AAR contents. Use `Bind="false"` or remove redundant references.
+
+### "Class 'X' does not implement interface member 'Y'"
+
+Covariant return types or interface implementation issues.
+
+**Solution:** Add custom implementation in `Additions/` folder:
+
+```csharp
+// Additions/MyClassAdditions.cs
+namespace Com.Example
+{
+    public partial class MyClass
+    {
+        Java.Lang.Object SomeInterface.SomeMethod()
+        {
+            return RawSomeMethod();
+        }
+    }
+}
+```
+
+### "Cannot find symbol" / "Package does not exist"
+
+Wrapper code references classes not available.
+
+**Solution:** Verify all dependencies are declared in `build.gradle.kts` and rebuild the AAR.
+
+### Gradle Build Failures
+
+```bash
+# Clean and rebuild
+./gradlew clean
+./gradlew :app:assembleRelease --stacktrace
+```
+
+## Runtime Errors
+
+### `Java.Lang.NoClassDefFoundError`
+
+Missing dependency at runtime.
+
+**Solution:** A required dependency was ignored. Remove it from `AndroidIgnoredJavaDependency` and properly satisfy it.
+
+### `Java.Lang.UnsatisfiedLinkError`
+
+Native library (.so) not loaded.
+
+**Solution:** 
+1. Ensure .so files are included in the AAR
+2. Call `JavaSystem.LoadLibrary()` if needed
+3. Check ABI compatibility (arm64-v8a, armeabi-v7a, x86_64)
+
+### `Java.Lang.IllegalStateException: Must call initialize() first`
+
+Library not initialized.
+
+**Solution:** Ensure you call `DotnetMyBinding.Initialize()` before using other methods.
+
+### Callback Not Invoked
+
+**Causes & Solutions:**
+1. **Callback on wrong thread** - Use `MainThread.BeginInvokeOnMainThread()` for UI updates
+2. **Callback garbage collected** - Store a strong reference to the callback object
+3. **Exception in native code** - Add try/catch in wrapper and check logcat
+
+## IntelliSense Issues
+
+**IntelliSense shows errors but project compiles:**
+This is normal for binding projects. The binding generator doesn't use source generators. Build the project first and IntelliSense will catch up (though some errors may persist).
+
+# Quick Reference
+
+## Wrapper Design Guidelines
+
+### Type Mapping
+
+Keep method signatures simple with types that marshal easily:
+
+| Java/Kotlin Type | C# Type | Notes |
+|------------------|---------|-------|
+| `String` | `string` | Direct mapping |
+| `boolean` / `Boolean` | `bool` | Direct mapping |
+| `int` / `Integer` | `int` | Direct mapping |
+| `long` / `Long` | `long` | Direct mapping |
+| `double` / `Double` | `double` | Direct mapping |
+| `float` / `Float` | `float` | Direct mapping |
+| `byte[]` | `byte[]` | Direct mapping |
+| `Context` | `Android.Content.Context` | Pass from platform |
+| `View` | `Android.Views.View` | For view creation |
+| `JSONObject` | `Org.Json.JSONObject` | For complex data |
+| Callback interface | `IJavaObject` implementation | See callback pattern |
+
+### Callback Interface Pattern
+
+```java
+// Java - define a simple callback interface
+public interface DataCallback {
+    void onSuccess(String result);
+    void onError(String error);
+}
+```
+
+```csharp
+// C# - implement the generated interface
+public class MyCallback : Java.Lang.Object, DotnetMyBinding.IDataCallback
+{
+    private readonly Action<string> _onSuccess;
+    private readonly Action<string> _onError;
+
+    public MyCallback(Action<string> onSuccess, Action<string> onError)
+    {
+        _onSuccess = onSuccess;
+        _onError = onError;
+    }
+
+    public void OnSuccess(string result) => _onSuccess(result);
+    public void OnError(string error) => _onError(error);
+}
+```
+
+### Things to Avoid in Wrapper API
+
+| Avoid | Use Instead |
+|-------|-------------|
+| Kotlin coroutines | Callback interfaces |
+| Kotlin lambdas | Java-style interfaces |
+| Kotlin data classes | Simple classes with getters |
+| Kotlin sealed classes | Enums or class hierarchy |
+| Generics (complex) | Specific types or Object |
+| Rx/Flow observables | Callback interfaces |
+
+## MSBuild Items Reference
+
+| Item | Purpose |
+|------|---------|
+| `<AndroidLibrary>` | Include AAR/JAR in binding |
+| `<AndroidMavenLibrary>` | Download and include from Maven |
+| `<AndroidIgnoredJavaDependency>` | Ignore a dependency (compile-time only) |
+| `<AndroidNativeLibrary>` | Include .so files |
+| `<TransformFile>` | Metadata transform files |
+| `<PackageReference>` | NuGet package reference |
+
+## Common Attributes
+
+| Attribute | Values | Purpose |
+|-----------|--------|---------|
+| `Bind` | `true`/`false` | Whether to generate C# bindings |
+| `Pack` | `true`/`false` | Whether to include in NuGet package |
+| `JavaArtifact` | `groupId:artifactId` | Declare what Maven artifact this satisfies |
+| `JavaVersion` | `version` | Version of the Maven artifact |
+| `Repository` | `Central`/`Google`/URL | Maven repository to download from |
+
+## Complete Script: Create Android Binding Project
+
+```bash
+#!/bin/bash
+set -e
+
+# Configuration
+BINDING_NAME="${1:-MyBinding}"
+PACKAGE_NAME="${2:-com.example.mybinding}"
+MIN_SDK="${3:-21}"
+GRADLE_VERSION="${4:-9.2.1}"
+AGP_VERSION="${5:-8.2.2}"
+
+echo "Creating Android binding project: ${BINDING_NAME}"
+echo "  Package: ${PACKAGE_NAME}"
+echo "  Min SDK: ${MIN_SDK}"
+echo "  Gradle: ${GRADLE_VERSION}"
+
+# Create directory structure
+mkdir -p ${BINDING_NAME}/android/native/app/src/main/java/${PACKAGE_NAME//./\/}
+mkdir -p ${BINDING_NAME}/android/${BINDING_NAME}.Android.Binding/Transforms
+mkdir -p ${BINDING_NAME}/sample/MauiSample
+
+cd ${BINDING_NAME}/android/native
+
+# Download and setup Gradle Wrapper (no global Gradle install needed)
+echo "Setting up Gradle Wrapper..."
+GRADLE_DIST_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"
+WRAPPER_JAR_URL="https://raw.githubusercontent.com/gradle/gradle/v${GRADLE_VERSION}/gradle/wrapper/gradle-wrapper.jar"
+
+mkdir -p gradle/wrapper
+cat > gradle/wrapper/gradle-wrapper.properties << EOF
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+EOF
+
+# Create gradlew script
+cat > gradlew << 'GRADLEW_EOF'
+#!/bin/sh
+# Gradle Wrapper script - downloads Gradle if needed
+exec java -jar "$(dirname "$0")/gradle/wrapper/gradle-wrapper.jar" "$@"
+GRADLEW_EOF
+chmod +x gradlew
+
+# Download gradle-wrapper.jar
+curl -sL -o gradle/wrapper/gradle-wrapper.jar \
+  "https://raw.githubusercontent.com/gradle/gradle/v${GRADLE_VERSION}/gradle/wrapper/gradle-wrapper.jar" 2>/dev/null || \
+  echo "Note: Could not download gradle-wrapper.jar. Run './gradlew' to auto-download."
+
+# Create settings.gradle.kts
+cat > settings.gradle.kts << EOF
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "${BINDING_NAME}Native"
+include(":app")
+EOF
+
+# Create root build.gradle.kts
+cat > build.gradle.kts << EOF
+plugins {
+    id("com.android.library") version "${AGP_VERSION}" apply false
+}
+EOF
+
+# Create app build.gradle.kts
+cat > app/build.gradle.kts << EOF
+plugins {
+    id("com.android.library")
+}
+
+android {
+    namespace = "${PACKAGE_NAME}"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = ${MIN_SDK}
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+        }
+    }
+    
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    // Add your native library dependency here
+    // implementation("com.thirdparty:awesomelib:1.0.0")
+    
+    implementation("androidx.core:core:1.12.0")
+}
+EOF
+
+# Create Java wrapper
+cat > app/src/main/java/${PACKAGE_NAME//./\/}/Dotnet${BINDING_NAME}.java << EOF
+package ${PACKAGE_NAME};
+
+import android.content.Context;
+import android.util.Log;
+
+public class Dotnet${BINDING_NAME} {
+    private static final String TAG = "Dotnet${BINDING_NAME}";
+    private static boolean initialized = false;
+
+    public static void initialize(Context context, boolean debug) {
+        if (initialized) return;
+        initialized = true;
+        Log.d(TAG, "${BINDING_NAME} initialized");
+    }
+
+    public static boolean isInitialized() {
+        return initialized;
+    }
+
+    public static String getVersion() {
+        return "1.0.0";
+    }
+    
+    public interface DataCallback {
+        void onSuccess(String result);
+        void onError(String error);
+    }
+    
+    public static void fetchDataAsync(String query, DataCallback callback) {
+        if (!initialized) {
+            callback.onError("Not initialized");
+            return;
+        }
+        callback.onSuccess("Result for: " + query);
+    }
+}
+EOF
+
+cd ../..
+
+# Create binding project using dotnet new template
+dotnet new androidbinding -n ${BINDING_NAME}.Android.Binding -o ${BINDING_NAME}.Android.Binding
+
+# Add the AAR reference to the generated csproj
+# The template creates a basic project, we need to add our specific items
+cat >> ${BINDING_NAME}.Android.Binding/${BINDING_NAME}.Android.Binding.csproj << EOF
+
+  <!-- Your wrapper AAR -->
+  <ItemGroup>
+    <AndroidLibrary Include="../native/app/build/outputs/aar/app-release.aar" />
+  </ItemGroup>
+
+  <!-- Dependencies -->
+  <ItemGroup>
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.12.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AndroidIgnoredJavaDependency Include="org.jetbrains:annotations" Version="*" />
+  </ItemGroup>
+EOF
+
+# Fix the csproj by moving the added items inside the Project element
+# (The template ends with </Project>, so we need to insert before it)
+sed -i '' 's/<\\/Project>//' ${BINDING_NAME}.Android.Binding/${BINDING_NAME}.Android.Binding.csproj
+echo "</Project>" >> ${BINDING_NAME}.Android.Binding/${BINDING_NAME}.Android.Binding.csproj
+
+# Update Metadata.xml with our namespace mapping
+cat > ${BINDING_NAME}.Android.Binding/Transforms/Metadata.xml << EOF
+<metadata>
+  <attr path="/api/package[@name='${PACKAGE_NAME}']" 
+        name="managedName">${BINDING_NAME}</attr>
+</metadata>
+EOF
+
+cd ..
+
+echo ""
+echo "✅ Created ${BINDING_NAME} Android binding project!"
+echo ""
+echo "Next steps:"
+echo "  1. cd ${BINDING_NAME}/android/native"
+echo "  2. Add your native library to app/build.gradle.kts"
+echo "  3. ./gradlew :app:assembleRelease"
+echo "  4. cd ../${BINDING_NAME}.Android.Binding"
+echo "  5. dotnet build"
+echo "  6. Resolve any dependency errors"
+```
+
+Save as `create-android-binding.sh` and run:
+
+```bash
+chmod +x create-android-binding.sh
+
+# Basic usage (uses defaults)
+./create-android-binding.sh MyAwesomeBinding
+
+# Full customization
+./create-android-binding.sh MyAwesomeBinding com.mycompany.mybinding 21 9.2.1 8.2.2
+#                          ^name             ^package                ^sdk ^gradle ^agp
+```
+
+> **Tip:** The script sets up Gradle Wrapper, so you don't need Gradle installed globally. The first `./gradlew` run will download the correct Gradle version automatically.
+
+# Resources
+
+## Official Documentation
+- [Binding a Java Library (Microsoft Docs)](https://learn.microsoft.com/dotnet/android/binding-libs/binding-java-libs/binding-java-library)
+- [Binding from Maven (Microsoft Docs)](https://learn.microsoft.com/dotnet/android/binding-libs/binding-java-libs/binding-java-maven-library)
+- [Java Dependency Verification](https://learn.microsoft.com/dotnet/android/binding-libs/advanced-concepts/java-dependency-verification)
+- [Resolving Java Dependencies](https://learn.microsoft.com/dotnet/android/binding-libs/advanced-concepts/resolving-java-dependencies)
+- [Java Bindings Metadata](https://learn.microsoft.com/dotnet/android/binding-libs/customizing-bindings/java-bindings-metadata)
+- [Native Library Interop - .NET Community Toolkit](https://learn.microsoft.com/dotnet/communitytoolkit/maui/native-library-interop)
+
+## Version Discovery
+- [Android Gradle Plugin Releases](https://developer.android.com/build/releases/gradle-plugin) - Check for latest AGP version
+- [Gradle Releases](https://gradle.org/releases/) - Check for latest Gradle version
+- [Kotlin Releases](https://kotlinlang.org/docs/releases.html) - Check for latest Kotlin version
+
+## Templates and Examples
+- [Maui.NativeLibraryInterop Repository](https://github.com/CommunityToolkit/Maui.NativeLibraryInterop)
+- [Xamarin.AndroidX Repository](https://github.com/xamarin/AndroidX)
+
+## Related Skills
+- See [docs/android-bindings-guide.md](../../../docs/android-bindings-guide.md) for comprehensive reference
+- See [ios-slim-bindings](../ios-slim-bindings/SKILL.md) for iOS bindings
+
+# Output Format
+
+When assisting with Android slim bindings, provide:
+
+1. **Dependency analysis** - Full dependency tree and NuGet mapping strategy
+2. **Project structure** - File/folder layout for the binding
+3. **Wrapper code** - Complete Java or Kotlin implementation
+4. **Gradle configuration** - build.gradle.kts with dependencies
+5. **C# binding project** - `.csproj` with proper dependency references
+6. **Metadata transforms** - Metadata.xml for namespace and parameter renaming
+7. **Usage examples** - How to call the binding from MAUI/C#
+8. **Troubleshooting guidance** - Common issues and solutions for the specific library
+
+Always verify:
+- All transitive dependencies are accounted for
+- NuGet packages match required Maven versions
+- Wrapper methods use simple, marshallable types
+- Callback interfaces are properly designed
+- Metadata.xml renames parameters to meaningful names

--- a/.claude/skills/ios-slim-bindings/SKILL.md
+++ b/.claude/skills/ios-slim-bindings/SKILL.md
@@ -1,0 +1,1524 @@
+---
+name: ios-slim-bindings
+description: Create and update slim/native platform interop bindings for iOS in .NET MAUI and .NET for iOS projects. Guides through creating Swift/Objective-C wrappers, configuring Xcode projects, generating C# API definitions, and integrating native iOS libraries using the Native Library Interop (NLI) approach. Use when asked about iOS bindings, xcframework integration, Swift interop, Objective Sharpie, or bridging native iOS SDKs to .NET.
+---
+
+# When to use this skill
+
+Activate this skill when the user asks:
+- How do I create iOS bindings for a native library?
+- How do I wrap an iOS SDK for use in .NET MAUI?
+- How do I create slim bindings for iOS?
+- How do I use Native Library Interop for iOS?
+- How do I bind a Swift library to .NET?
+- How do I use Objective Sharpie for iOS bindings?
+- How do I integrate an xcframework into .NET MAUI?
+- How do I create a Swift wrapper for a native iOS library?
+- How do I update iOS bindings when the native SDK changes?
+- How do I fix iOS binding build errors?
+- How do I expose native iOS APIs to C#?
+- How do I handle CocoaPods dependencies in iOS bindings?
+- How do I handle Swift Package Manager dependencies?
+
+# Overview
+
+This skill guides the creation of **Native Library Interop (Slim Bindings)** for iOS. This modern approach creates a thin native Swift/Objective-C wrapper exposing only the APIs you need from a native iOS library, making bindings easier to create and maintain.
+
+## When to Use Slim Bindings vs Traditional Bindings
+
+| Scenario | Recommended Approach |
+|----------|---------------------|
+| Need only a subset of library functionality | **Slim Bindings** ✓ |
+| Easier maintenance when SDK updates | **Slim Bindings** ✓ |
+| Prefer working in Swift/Objective-C for wrapper | **Slim Bindings** ✓ |
+| Better isolation from breaking changes | **Slim Bindings** ✓ |
+| Need entire library API surface | Traditional Bindings |
+| Creating bindings for third-party developers | Traditional Bindings |
+| Already maintaining traditional bindings | Traditional Bindings |
+
+# Inputs
+
+| Parameter | Required | Example | Notes |
+|-----------|----------|---------|-------|
+| libraryName | yes | `FirebaseMessaging`, `Lottie` | Name of the native iOS library to bind |
+| bindingProjectName | yes | `MyBinding.MaciOS` | Name for the C# binding project |
+| dependencySource | no | `cocoapods`, `spm`, `xcframework` | How the native library is distributed |
+| targetFrameworks | no | `net9.0-ios;net9.0-maccatalyst` | Target frameworks (default: latest .NET iOS + Mac Catalyst) |
+| exposedApis | no | List of specific APIs | Which native APIs to expose (helps scope the wrapper) |
+
+# Project Structure
+
+The recommended project structure for Native Library Interop:
+
+```
+MyBinding/
+├── macios/
+│   ├── native/
+│   │   └── MyBinding/                    # Xcode project
+│   │       ├── MyBinding.xcodeproj/
+│   │       │   └── project.pbxproj
+│   │       ├── MyBinding/
+│   │       │   └── DotnetMyBinding.swift  # Swift wrapper implementation
+│   │       └── Podfile                    # If using CocoaPods
+│   │       └── Package.swift              # If using Swift Package Manager
+│   └── MyBinding.MaciOS.Binding/
+│       ├── MyBinding.MaciOS.Binding.csproj
+│       └── ApiDefinition.cs
+├── sample/
+│   └── MauiSample/                        # Sample MAUI app
+│       ├── MauiSample.csproj
+│       └── MainPage.xaml.cs
+└── README.md
+```
+
+# Step-by-step Process
+
+## Step 1: Create Project Structure from Command Line
+
+This section shows how to create the entire binding project structure using only command-line tools—no GUI or template cloning required.
+
+### Prerequisites
+
+Install XcodeGen (generates Xcode projects from YAML):
+
+```bash
+brew install xcodegen
+```
+
+### Create Directory Structure
+
+```bash
+# Set your binding name
+BINDING_NAME="MyBinding"
+
+# Create the full directory structure
+mkdir -p ${BINDING_NAME}/macios/native/${BINDING_NAME}/${BINDING_NAME}
+mkdir -p ${BINDING_NAME}/macios/${BINDING_NAME}.MaciOS.Binding
+mkdir -p ${BINDING_NAME}/sample/MauiSample
+
+cd ${BINDING_NAME}
+```
+
+## Step 2: Create the Xcode Project with XcodeGen
+
+### Create the XcodeGen Project Spec
+
+Create `macios/native/${BINDING_NAME}/project.yml`:
+
+```bash
+cat > macios/native/${BINDING_NAME}/project.yml << 'EOF'
+name: MyBinding
+options:
+  bundleIdPrefix: com.example
+  deploymentTarget:
+    iOS: "15.0"
+    macOS: "12.0"
+  xcodeVersion: "15.0"
+  generateEmptyDirectories: true
+
+settings:
+  base:
+    MARKETING_VERSION: "1.0.0"
+    CURRENT_PROJECT_VERSION: "1"
+    BUILD_LIBRARY_FOR_DISTRIBUTION: YES
+    SKIP_INSTALL: NO
+    MACH_O_TYPE: staticlib
+    SWIFT_VERSION: "5.0"
+    ENABLE_BITCODE: NO
+    DEFINES_MODULE: YES
+
+targets:
+  MyBinding:
+    type: framework
+    platform: iOS
+    sources:
+      - path: MyBinding
+        type: group
+    settings:
+      base:
+        INFOPLIST_FILE: MyBinding/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.mybinding
+        PRODUCT_NAME: MyBinding
+        TARGETED_DEVICE_FAMILY: "1,2"
+    scheme:
+      gatherCoverageData: false
+      shared: true
+EOF
+```
+
+### Create the Swift Source File
+
+Create the Swift wrapper file:
+
+```bash
+cat > macios/native/${BINDING_NAME}/${BINDING_NAME}/Dotnet${BINDING_NAME}.swift << 'EOF'
+import Foundation
+import UIKit
+
+/// Main binding class exposed to .NET
+@objc(DotnetMyBinding)
+public class DotnetMyBinding: NSObject {
+    
+    /// Initialize the native library
+    @objc(initialize)
+    public static func initialize() {
+        // Initialize your native library here
+        print("MyBinding initialized")
+    }
+    
+    /// Example synchronous method
+    @objc(getVersion)
+    public static func getVersion() -> String {
+        return "1.0.0"
+    }
+    
+    /// Example async method with completion handler
+    @objc(fetchDataWithQuery:completion:)
+    public static func fetchData(
+        query: String,
+        completion: @escaping (String?, NSError?) -> Void
+    ) {
+        // Simulate async operation
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            completion("Result for: \(query)", nil)
+        }
+    }
+    
+    /// Example view creation
+    @objc(createViewWithFrame:)
+    public static func createView(frame: CGRect) -> UIView {
+        let view = UIView(frame: frame)
+        view.backgroundColor = .systemBlue
+        return view
+    }
+}
+EOF
+```
+
+### Create Info.plist
+
+```bash
+cat > macios/native/${BINDING_NAME}/${BINDING_NAME}/Info.plist << 'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>NSPrincipalClass</key>
+    <string></string>
+</dict>
+</plist>
+EOF
+```
+
+### Generate the Xcode Project
+
+```bash
+cd macios/native/${BINDING_NAME}
+xcodegen generate
+cd ../../..
+```
+
+This creates `MyBinding.xcodeproj` with all the correct build settings.
+
+### Verify the Generated Project
+
+```bash
+# List the generated files
+ls -la macios/native/${BINDING_NAME}/
+
+# Verify the scheme was created and is shared
+ls -la macios/native/${BINDING_NAME}/${BINDING_NAME}.xcodeproj/xcshareddata/xcschemes/
+```
+
+## Step 3: Create the C# Binding Project
+
+### Create the Binding .csproj
+
+```bash
+cat > macios/${BINDING_NAME}.MaciOS.Binding/${BINDING_NAME}.MaciOS.Binding.csproj << 'EOF'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <IsBindingProject>true</IsBindingProject>
+    
+    <!-- Package metadata -->
+    <PackageId>MyBinding.MaciOS</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Your Name</Authors>
+    <Description>iOS bindings for MyBinding</Description>
+  </PropertyGroup>
+
+  <!-- Reference the Xcode project -->
+  <ItemGroup>
+    <XcodeProject Include="../native/MyBinding/MyBinding.xcodeproj">
+      <SchemeName>MyBinding</SchemeName>
+    </XcodeProject>
+  </ItemGroup>
+
+  <!-- API definition -->
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+  </ItemGroup>
+</Project>
+EOF
+```
+
+### Create Initial ApiDefinition.cs
+
+```bash
+cat > macios/${BINDING_NAME}.MaciOS.Binding/ApiDefinition.cs << 'EOF'
+using System;
+using Foundation;
+using ObjCRuntime;
+using UIKit;
+
+namespace MyBinding
+{
+    // @interface DotnetMyBinding : NSObject
+    [BaseType(typeof(NSObject))]
+    interface DotnetMyBinding
+    {
+        // +(void)initialize;
+        [Static]
+        [Export("initialize")]
+        void Initialize();
+
+        // +(NSString * _Nonnull)getVersion;
+        [Static]
+        [Export("getVersion")]
+        string GetVersion();
+
+        // +(void)fetchDataWithQuery:(NSString * _Nonnull)query completion:(void (^ _Nonnull)(NSString * _Nullable, NSError * _Nullable))completion;
+        [Static]
+        [Export("fetchDataWithQuery:completion:")]
+        [Async]
+        void FetchData(string query, Action<string?, NSError?> completion);
+
+        // +(UIView * _Nonnull)createViewWithFrame:(CGRect)frame;
+        [Static]
+        [Export("createViewWithFrame:")]
+        UIView CreateView(CGRect frame);
+    }
+}
+EOF
+```
+
+## Step 4: Build and Verify
+
+### Build the Binding Project
+
+```bash
+cd macios/${BINDING_NAME}.MaciOS.Binding
+dotnet build
+```
+
+This will:
+1. Invoke XcodeBuild to compile the native framework
+2. Create the xcframework
+3. Generate the C# binding assembly
+
+### Verify the Build Output
+
+```bash
+# Check that the xcframework was created
+find bin -name "*.xcframework" -type d
+
+# Find the generated Swift header (for updating ApiDefinition.cs later)
+find bin -name "*-Swift.h" -type f
+```
+
+## Optional: Add CocoaPods Support
+
+If your native library uses CocoaPods dependencies:
+
+### Create Podfile
+
+```bash
+cat > macios/native/${BINDING_NAME}/Podfile << 'EOF'
+platform :ios, '15.0'
+
+target 'MyBinding' do
+  use_frameworks! :linkage => :static
+  
+  # Add your pods here
+  # pod 'FirebaseMessaging', '~> 10.0'
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
+    end
+  end
+end
+EOF
+```
+
+### Install Pods and Update Project Reference
+
+```bash
+cd macios/native/${BINDING_NAME}
+pod install
+cd ../../..
+
+# Update the binding project to use xcworkspace instead of xcodeproj
+sed -i '' 's/\.xcodeproj/\.xcworkspace/g' macios/${BINDING_NAME}.MaciOS.Binding/${BINDING_NAME}.MaciOS.Binding.csproj
+```
+
+## Complete Script: Create Binding Project
+
+Here's a complete bash script that creates everything:
+
+```bash
+#!/bin/bash
+set -e
+
+# Configuration
+BINDING_NAME="${1:-MyBinding}"
+BUNDLE_ID_PREFIX="${2:-com.example}"
+MIN_IOS_VERSION="${3:-15.0}"
+
+echo "Creating iOS binding project: ${BINDING_NAME}"
+
+# Check prerequisites
+if ! command -v xcodegen &> /dev/null; then
+    echo "Installing xcodegen..."
+    brew install xcodegen
+fi
+
+# Create directory structure
+mkdir -p ${BINDING_NAME}/macios/native/${BINDING_NAME}/${BINDING_NAME}
+mkdir -p ${BINDING_NAME}/macios/${BINDING_NAME}.MaciOS.Binding
+cd ${BINDING_NAME}
+
+# Create XcodeGen project spec
+cat > macios/native/${BINDING_NAME}/project.yml << EOF
+name: ${BINDING_NAME}
+options:
+  bundleIdPrefix: ${BUNDLE_ID_PREFIX}
+  deploymentTarget:
+    iOS: "${MIN_IOS_VERSION}"
+    macOS: "12.0"
+  xcodeVersion: "15.0"
+  generateEmptyDirectories: true
+
+settings:
+  base:
+    MARKETING_VERSION: "1.0.0"
+    CURRENT_PROJECT_VERSION: "1"
+    BUILD_LIBRARY_FOR_DISTRIBUTION: YES
+    SKIP_INSTALL: NO
+    MACH_O_TYPE: staticlib
+    SWIFT_VERSION: "5.0"
+    ENABLE_BITCODE: NO
+    DEFINES_MODULE: YES
+
+targets:
+  ${BINDING_NAME}:
+    type: framework
+    platform: iOS
+    sources:
+      - path: ${BINDING_NAME}
+        type: group
+    settings:
+      base:
+        INFOPLIST_FILE: ${BINDING_NAME}/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: ${BUNDLE_ID_PREFIX}.${BINDING_NAME,,}
+        PRODUCT_NAME: ${BINDING_NAME}
+        TARGETED_DEVICE_FAMILY: "1,2"
+    scheme:
+      gatherCoverageData: false
+      shared: true
+EOF
+
+# Create Swift wrapper
+cat > macios/native/${BINDING_NAME}/${BINDING_NAME}/Dotnet${BINDING_NAME}.swift << EOF
+import Foundation
+import UIKit
+
+@objc(Dotnet${BINDING_NAME})
+public class Dotnet${BINDING_NAME}: NSObject {
+    
+    @objc(initialize)
+    public static func initialize() {
+        print("${BINDING_NAME} initialized")
+    }
+    
+    @objc(getVersion)
+    public static func getVersion() -> String {
+        return "1.0.0"
+    }
+}
+EOF
+
+# Create Info.plist
+cat > macios/native/${BINDING_NAME}/${BINDING_NAME}/Info.plist << 'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>
+EOF
+
+# Generate Xcode project
+cd macios/native/${BINDING_NAME}
+xcodegen generate
+cd ../../..
+
+# Create binding .csproj
+cat > macios/${BINDING_NAME}.MaciOS.Binding/${BINDING_NAME}.MaciOS.Binding.csproj << EOF
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <IsBindingProject>true</IsBindingProject>
+    <PackageId>${BINDING_NAME}.MaciOS</PackageId>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <XcodeProject Include="../native/${BINDING_NAME}/${BINDING_NAME}.xcodeproj">
+      <SchemeName>${BINDING_NAME}</SchemeName>
+    </XcodeProject>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+  </ItemGroup>
+</Project>
+EOF
+
+# Create ApiDefinition.cs
+cat > macios/${BINDING_NAME}.MaciOS.Binding/ApiDefinition.cs << EOF
+using System;
+using Foundation;
+using ObjCRuntime;
+using UIKit;
+
+namespace ${BINDING_NAME}
+{
+    [BaseType(typeof(NSObject))]
+    interface Dotnet${BINDING_NAME}
+    {
+        [Static]
+        [Export("initialize")]
+        void Initialize();
+
+        [Static]
+        [Export("getVersion")]
+        string GetVersion();
+    }
+}
+EOF
+
+echo ""
+echo "✅ Created ${BINDING_NAME} binding project!"
+echo ""
+echo "Structure:"
+find . -type f -name "*.swift" -o -name "*.cs" -o -name "*.csproj" -o -name "project.yml" | sort
+echo ""
+echo "Next steps:"
+echo "  1. cd ${BINDING_NAME}/macios/${BINDING_NAME}.MaciOS.Binding"
+echo "  2. dotnet build"
+echo "  3. Add your native library code to Dotnet${BINDING_NAME}.swift"
+echo "  4. Update ApiDefinition.cs to match your Swift API"
+```
+
+Save as `create-ios-binding.sh` and run:
+```bash
+chmod +x create-ios-binding.sh
+./create-ios-binding.sh MyAwesomeBinding com.mycompany 15.0
+```
+
+---
+
+## Alternative: Create Xcode Project Manually (Without XcodeGen)
+
+If you prefer not to use XcodeGen, you can create a minimal Xcode project using `plutil` and direct file creation. However, this is more complex and error-prone.
+
+### Using Swift Package as Alternative
+
+For simpler cases, you can use Swift Package Manager instead of an Xcode project:
+
+```bash
+cd macios/native
+mkdir ${BINDING_NAME}
+cd ${BINDING_NAME}
+
+# Initialize Swift package
+swift package init --type library --name ${BINDING_NAME}
+
+# The binding project can reference the Package.swift
+```
+
+Then update the binding `.csproj` to use `<XcodeProject>` pointing to the directory containing `Package.swift`.
+
+> **Note:** The `<XcodeProject>` MSBuild item supports both `.xcodeproj` and Swift Package directories.
+
+## Step 5: Add Native Library Dependencies
+
+Choose the appropriate method for your library's distribution:
+
+### Option A: CocoaPods
+
+Create `macios/native/MyBinding/Podfile`:
+
+```ruby
+platform :ios, '15.0'
+
+target 'MyBinding' do
+  use_frameworks! :linkage => :static
+  
+  # Add your native library pod
+  pod 'FirebaseMessaging', '~> 10.0'
+  # Add other dependencies as needed
+  pod 'FirebaseCore'
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
+    end
+  end
+end
+```
+
+Install dependencies:
+
+```bash
+cd macios/native/MyBinding
+pod install
+# After this, open MyBinding.xcworkspace instead of .xcodeproj
+```
+
+### Option B: Swift Package Manager
+
+In Xcode:
+1. **File → Add Package Dependencies**
+2. Enter the package repository URL
+3. Select version rules
+4. Add to your target
+
+Or create `Package.swift`:
+
+```swift
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "MyBinding",
+    platforms: [.iOS(.v15), .macCatalyst(.v15)],
+    products: [
+        .library(name: "MyBinding", type: .static, targets: ["MyBinding"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/example/SomeLibrary.git", from: "1.0.0")
+    ],
+    targets: [
+        .target(
+            name: "MyBinding",
+            dependencies: [
+                .product(name: "SomeLibrary", package: "SomeLibrary")
+            ]
+        )
+    ]
+)
+```
+
+### Option C: Manual XCFramework
+
+1. Drag the `.xcframework` into the Xcode project
+2. Ensure "Copy items if needed" is checked
+3. Add to target's "Frameworks and Libraries" section
+4. Set "Embed" to **Do Not Embed** (for static linking)
+
+## Step 6: Implement the Swift Wrapper
+
+Create `macios/native/MyBinding/MyBinding/DotnetMyBinding.swift`:
+
+```swift
+import Foundation
+import UIKit
+import TheNativeLibrary  // Import your native library
+
+/// Main binding class exposed to .NET
+/// The @objc attribute with explicit name ensures stable Objective-C naming
+@objc(DotnetMyBinding)
+public class DotnetMyBinding: NSObject {
+    
+    // MARK: - Initialization
+    
+    /// Initialize the native library
+    /// Call this from your .NET app's startup (e.g., MauiProgram.cs)
+    @objc(initializeWithApiKey:)
+    public static func initialize(apiKey: String) {
+        TheNativeLibrary.configure(withApiKey: apiKey)
+    }
+    
+    /// Check if the library is initialized
+    @objc(isInitialized)
+    public static func isInitialized() -> Bool {
+        return TheNativeLibrary.isConfigured
+    }
+    
+    // MARK: - Synchronous Methods
+    
+    /// Get a simple value from the native library
+    @objc(getVersion)
+    public static func getVersion() -> String {
+        return TheNativeLibrary.version
+    }
+    
+    /// Process data and return result
+    @objc(processDataWithInput:)
+    public static func processData(input: String) -> String? {
+        guard let result = TheNativeLibrary.process(input) else {
+            return nil
+        }
+        return result.stringValue
+    }
+    
+    // MARK: - Asynchronous Methods (Completion Handlers)
+    
+    /// Perform async operation with completion handler
+    /// .NET can use [Async] attribute to generate async/await version
+    @objc(fetchDataWithQuery:completion:)
+    public static func fetchData(
+        query: String,
+        completion: @escaping (String?, NSError?) -> Void
+    ) {
+        TheNativeLibrary.fetch(query: query) { result in
+            switch result {
+            case .success(let data):
+                completion(data.stringValue, nil)
+            case .failure(let error):
+                completion(nil, error as NSError)
+            }
+        }
+    }
+    
+    /// Async method with complex result data
+    @objc(performOperationWithConfig:completion:)
+    public static func performOperation(
+        config: NSDictionary,
+        completion: @escaping (NSData?, NSError?) -> Void
+    ) {
+        guard let configDict = config as? [String: Any] else {
+            let error = NSError(
+                domain: "DotnetMyBinding",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid configuration"]
+            )
+            completion(nil, error)
+            return
+        }
+        
+        TheNativeLibrary.performOperation(config: configDict) { result in
+            switch result {
+            case .success(let data):
+                completion(data, nil)
+            case .failure(let error):
+                completion(nil, error as NSError)
+            }
+        }
+    }
+    
+    // MARK: - View Creation
+    
+    /// Create a native view to embed in .NET MAUI
+    /// Return UIView for cross-platform compatibility
+    @objc(createViewWithFrame:)
+    public static func createView(frame: CGRect) -> UIView {
+        let nativeView = TheNativeLibrary.createCustomView()
+        nativeView.frame = frame
+        return nativeView
+    }
+    
+    /// Create a configured view with options
+    @objc(createViewWithFrame:options:)
+    public static func createView(frame: CGRect, options: NSDictionary) -> UIView {
+        let config = options as? [String: Any] ?? [:]
+        let nativeView = TheNativeLibrary.createCustomView(options: config)
+        nativeView.frame = frame
+        return nativeView
+    }
+    
+    // MARK: - Delegate/Callback Pattern
+    
+    private static var callbackHandler: ((String) -> Void)?
+    
+    /// Register a callback for events
+    /// .NET will pass an Action<string> that gets invoked
+    @objc(registerCallbackWithHandler:)
+    public static func registerCallback(handler: @escaping (String) -> Void) {
+        callbackHandler = handler
+        TheNativeLibrary.setEventHandler { event in
+            callbackHandler?(event.description)
+        }
+    }
+    
+    /// Unregister the callback
+    @objc(unregisterCallback)
+    public static func unregisterCallback() {
+        callbackHandler = nil
+        TheNativeLibrary.setEventHandler(nil)
+    }
+}
+```
+
+### Swift Wrapper Design Guidelines
+
+#### Type Mapping Rules
+
+Only use types that .NET already knows how to marshal:
+
+| Swift Type | Objective-C Type | C# Type |
+|------------|------------------|---------|
+| `String` | `NSString *` | `string` |
+| `Bool` | `BOOL` | `bool` |
+| `Int`, `Int32` | `int` | `int` |
+| `Int64` | `long long` | `long` |
+| `Double` | `double` | `double` |
+| `Float` | `float` | `float` |
+| `Data` | `NSData *` | `NSData` |
+| `[String: Any]` | `NSDictionary *` | `NSDictionary` |
+| `[Any]` | `NSArray *` | `NSArray` |
+| `UIView` | `UIView *` | `UIView` |
+| `UIImage` | `UIImage *` | `UIImage` |
+| `URL` | `NSURL *` | `NSUrl` |
+| Custom Class | Must inherit `NSObject` | Interface with `[BaseType]` |
+
+#### Required Annotations
+
+```swift
+// Class: Must be public and have @objc with explicit name
+@objc(ClassName)
+public class ClassName: NSObject {
+
+    // Method: Must be public with @objc selector
+    @objc(methodNameWithParam:anotherParam:)
+    public func methodName(param: String, anotherParam: Int) -> Bool {
+        // Implementation
+    }
+    
+    // Static method
+    @objc(staticMethodWithValue:)
+    public static func staticMethod(value: String) -> String {
+        // Implementation
+    }
+    
+    // Property (read-only)
+    @objc(propertyName)
+    public var propertyName: String {
+        return "value"
+    }
+    
+    // Property (read-write)
+    @objc
+    public var readWriteProperty: String = ""
+}
+```
+
+#### Completion Handler Pattern
+
+For async operations, use completion handlers that .NET can convert to `async`/`await`:
+
+```swift
+// Swift
+@objc(operationWithInput:completion:)
+public static func operation(
+    input: String,
+    completion: @escaping (String?, NSError?) -> Void  // Result, Error
+) {
+    // Async work...
+    DispatchQueue.main.async {
+        completion(result, nil)  // Success
+        // OR
+        completion(nil, error as NSError)  // Failure
+    }
+}
+```
+
+```csharp
+// C# ApiDefinition.cs - Add [Async] for automatic async wrapper
+[Static]
+[Export("operationWithInput:completion:")]
+[Async]
+void Operation(string input, Action<string?, NSError?> completion);
+
+// Usage in C#
+var result = await DotnetMyBinding.OperationAsync("input");
+```
+
+#### Error Handling Pattern
+
+Always convert errors to `NSError` for proper propagation:
+
+```swift
+@objc(riskyOperationWithCompletion:)
+public static func riskyOperation(completion: @escaping (Bool, NSError?) -> Void) {
+    do {
+        try TheNativeLibrary.riskyOperation()
+        completion(true, nil)
+    } catch {
+        let nsError = NSError(
+            domain: "DotnetMyBinding",
+            code: (error as NSError).code,
+            userInfo: [
+                NSLocalizedDescriptionKey: error.localizedDescription,
+                NSUnderlyingErrorKey: error
+            ]
+        )
+        completion(false, nsError)
+    }
+}
+```
+
+## Step 7: Create the C# Binding Project (If Not Using Script)
+
+If you created the project using the script in Step 1-4, skip to Step 8.
+
+Create `macios/MyBinding.MaciOS.Binding/MyBinding.MaciOS.Binding.csproj`:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <IsBindingProject>true</IsBindingProject>
+    
+    <!-- Optional: Package metadata for NuGet -->
+    <PackageId>MyBinding.MaciOS</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Your Name</Authors>
+    <Description>iOS bindings for MyLibrary</Description>
+  </PropertyGroup>
+
+  <!-- Reference the Xcode project - MSBuild will build it automatically -->
+  <ItemGroup>
+    <XcodeProject Include="../native/MyBinding/MyBinding.xcodeproj">
+      <SchemeName>MyBinding</SchemeName>
+      <!-- Optional overrides -->
+      <!-- <Configuration>Release</Configuration> -->
+      <!-- <Kind>Framework</Kind> -->
+      <!-- <SmartLink>true</SmartLink> -->
+    </XcodeProject>
+  </ItemGroup>
+
+  <!-- If using xcworkspace (CocoaPods), reference it instead -->
+  <!--
+  <ItemGroup>
+    <XcodeProject Include="../native/MyBinding/MyBinding.xcworkspace">
+      <SchemeName>MyBinding</SchemeName>
+    </XcodeProject>
+  </ItemGroup>
+  -->
+
+  <!-- API definition file -->
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+  </ItemGroup>
+</Project>
+```
+
+### XcodeProject Properties
+
+| Property | Description | Default |
+|----------|-------------|---------|
+| `SchemeName` | Xcode scheme to build | Required |
+| `Configuration` | Build configuration | `Release` |
+| `Kind` | `Framework` or `Static` | Auto-detected |
+| `SmartLink` | Enable smart linking | `true` |
+| `ForceLoad` | Force load all symbols | `false` |
+
+## Step 8: Build and Generate API Definition
+
+### Initial Build
+
+Build the binding project to compile the native framework:
+
+```bash
+cd macios/MyBinding.MaciOS.Binding
+dotnet build
+```
+
+This creates the xcframework at:
+```
+bin/Debug/net9.0-ios/MyBinding.MaciOS.Binding.resources/MyBindingiOS.xcframework/
+```
+
+### Locate the Generated Swift Header
+
+After building, find the generated Objective-C header:
+
+```bash
+# Find the Swift header
+find bin -name "*-Swift.h" -type f
+
+# Typical location:
+# bin/Debug/net9.0-ios/MyBinding.MaciOS.Binding.resources/
+#   MyBindingiOS.xcframework/ios-arm64/MyBinding.framework/Headers/MyBinding-Swift.h
+```
+
+### Generate ApiDefinition.cs with Objective Sharpie
+
+Install Objective Sharpie if not already installed:
+
+```bash
+brew install --cask objectivesharpie
+```
+
+Check available iOS SDKs:
+
+```bash
+sharpie xcode -sdks
+```
+
+Generate bindings:
+
+```bash
+# Set variables for clarity
+HEADER_PATH="bin/Debug/net9.0-ios/MyBinding.MaciOS.Binding.resources/MyBindingiOS.xcframework/ios-arm64/MyBinding.framework/Headers/MyBinding-Swift.h"
+SDK_VERSION="iphoneos18.0"  # Use your installed SDK version
+NAMESPACE="MyBinding"
+
+sharpie bind \
+  --output=sharpie-output \
+  --namespace=$NAMESPACE \
+  --sdk=$SDK_VERSION \
+  --scope=Headers \
+  "$HEADER_PATH"
+```
+
+### Review and Clean Up Generated Code
+
+The generated `ApiDefinition.cs` requires cleanup:
+
+```csharp
+using System;
+using Foundation;
+using ObjCRuntime;
+using UIKit;
+
+namespace MyBinding
+{
+    // @interface DotnetMyBinding : NSObject
+    [BaseType(typeof(NSObject))]
+    interface DotnetMyBinding
+    {
+        // +(void)initializeWithApiKey:(NSString * _Nonnull)apiKey;
+        [Static]
+        [Export("initializeWithApiKey:")]
+        void Initialize(string apiKey);
+
+        // +(BOOL)isInitialized;
+        [Static]
+        [Export("isInitialized")]
+        bool IsInitialized { get; }
+
+        // +(NSString * _Nonnull)getVersion;
+        [Static]
+        [Export("getVersion")]
+        string GetVersion();
+
+        // +(NSString * _Nullable)processDataWithInput:(NSString * _Nonnull)input;
+        [Static]
+        [Export("processDataWithInput:")]
+        [return: NullAllowed]
+        string ProcessData(string input);
+
+        // +(void)fetchDataWithQuery:(NSString * _Nonnull)query 
+        //                completion:(void (^ _Nonnull)(NSString * _Nullable, NSError * _Nullable))completion;
+        [Static]
+        [Export("fetchDataWithQuery:completion:")]
+        [Async]  // Generates FetchDataAsync method
+        void FetchData(string query, Action<string?, NSError?> completion);
+
+        // +(void)performOperationWithConfig:(NSDictionary * _Nonnull)config 
+        //                        completion:(void (^ _Nonnull)(NSData * _Nullable, NSError * _Nullable))completion;
+        [Static]
+        [Export("performOperationWithConfig:completion:")]
+        [Async]
+        void PerformOperation(NSDictionary config, Action<NSData?, NSError?> completion);
+
+        // +(UIView * _Nonnull)createViewWithFrame:(CGRect)frame;
+        [Static]
+        [Export("createViewWithFrame:")]
+        UIView CreateView(CGRect frame);
+
+        // +(UIView * _Nonnull)createViewWithFrame:(CGRect)frame options:(NSDictionary * _Nonnull)options;
+        [Static]
+        [Export("createViewWithFrame:options:")]
+        UIView CreateView(CGRect frame, NSDictionary options);
+
+        // +(void)registerCallbackWithHandler:(void (^ _Nonnull)(NSString * _Nonnull))handler;
+        [Static]
+        [Export("registerCallbackWithHandler:")]
+        void RegisterCallback(Action<string> handler);
+
+        // +(void)unregisterCallback;
+        [Static]
+        [Export("unregisterCallback")]
+        void UnregisterCallback();
+    }
+}
+```
+
+### Common Cleanup Tasks
+
+| Issue | Solution |
+|-------|----------|
+| Missing namespace | Add `namespace MyBinding { ... }` |
+| `[Verify]` attributes | Review each, remove after confirming correctness |
+| `InitWithCoder` constructors | Remove - conflicts with linker |
+| Protocol type mismatches | Use interface types (e.g., `ICAAnimation`) |
+| Missing `[NullAllowed]` | Add for nullable parameters/returns |
+| Completion handlers | Add `[Async]` attribute for async generation |
+
+## Step 9: Build the Final Binding
+
+```bash
+cd macios/MyBinding.MaciOS.Binding
+dotnet build -c Release
+```
+
+Verify the output:
+```bash
+ls -la bin/Release/net9.0-ios/
+# Should contain: MyBinding.MaciOS.Binding.dll and resources
+```
+
+## Step 10: Use in Your MAUI App
+
+### Add Project Reference
+
+In your MAUI app's `.csproj`:
+
+```xml
+<ItemGroup Condition="$(TargetFramework.Contains('ios')) Or $(TargetFramework.Contains('maccatalyst'))">
+  <ProjectReference Include="..\..\macios\MyBinding.MaciOS.Binding\MyBinding.MaciOS.Binding.csproj" />
+</ItemGroup>
+```
+
+### Initialize in MauiProgram.cs
+
+```csharp
+using Microsoft.Maui.Hosting;
+
+#if IOS || MACCATALYST
+using MyBinding;
+#endif
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder.UseMauiApp<App>();
+
+#if IOS || MACCATALYST
+        // Initialize the native library
+        DotnetMyBinding.Initialize("your-api-key");
+#endif
+
+        return builder.Build();
+    }
+}
+```
+
+### Use Async APIs
+
+```csharp
+#if IOS || MACCATALYST
+using MyBinding;
+#endif
+
+public partial class MainPage : ContentPage
+{
+    private async void OnFetchClicked(object sender, EventArgs e)
+    {
+#if IOS || MACCATALYST
+        try
+        {
+            // Using the async version generated by [Async] attribute
+            var result = await DotnetMyBinding.FetchDataAsync("my query");
+            await DisplayAlert("Success", result ?? "No data", "OK");
+        }
+        catch (NSErrorException ex)
+        {
+            await DisplayAlert("Error", ex.Error.LocalizedDescription, "OK");
+        }
+#endif
+    }
+
+    private void OnCreateViewClicked(object sender, EventArgs e)
+    {
+#if IOS || MACCATALYST
+        var nativeView = DotnetMyBinding.CreateView(new CoreGraphics.CGRect(0, 0, 300, 200));
+        
+        // Add to a MAUI view using a custom handler or platform view
+        // This requires additional platform-specific integration
+#endif
+    }
+}
+```
+
+### Register Callbacks
+
+```csharp
+#if IOS || MACCATALYST
+protected override void OnAppearing()
+{
+    base.OnAppearing();
+    DotnetMyBinding.RegisterCallback((message) =>
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            StatusLabel.Text = $"Event: {message}";
+        });
+    });
+}
+
+protected override void OnDisappearing()
+{
+    base.OnDisappearing();
+    DotnetMyBinding.UnregisterCallback();
+}
+#endif
+```
+
+# Updating Bindings When Native SDK Changes
+
+## Step-by-step Update Process
+
+### 1. Update Native Dependency Version
+
+**CocoaPods:**
+```ruby
+# Podfile
+pod 'FirebaseMessaging', '~> 11.0'  # Updated version
+```
+
+```bash
+cd macios/native/MyBinding
+pod update
+```
+
+**Swift Package Manager:**
+Update version in Xcode's Package Dependencies or `Package.swift`
+
+**Manual XCFramework:**
+Replace the xcframework file with the new version
+
+### 2. Update Swift Wrapper (If Needed)
+
+Review release notes for the native library and update `DotnetMyBinding.swift`:
+- Add new methods for new APIs
+- Update method signatures for changed APIs
+- Remove deprecated API wrappers
+- Handle any breaking changes
+
+### 3. Regenerate API Definition
+
+```bash
+# Clean and rebuild
+cd macios/MyBinding.MaciOS.Binding
+dotnet clean
+dotnet build
+
+# Regenerate Objective Sharpie output
+sharpie bind \
+  --output=sharpie-output-new \
+  --namespace=MyBinding \
+  --sdk=iphoneos18.0 \
+  --scope=Headers \
+  "bin/Debug/net9.0-ios/MyBinding.MaciOS.Binding.resources/MyBindingiOS.xcframework/ios-arm64/MyBinding.framework/Headers/MyBinding-Swift.h"
+```
+
+### 4. Diff and Merge Changes
+
+Compare the new Sharpie output with existing `ApiDefinition.cs`:
+
+```bash
+diff ApiDefinition.cs sharpie-output-new/ApiDefinitions.cs
+```
+
+Manually merge:
+- Add new method bindings
+- Update changed signatures
+- Remove deleted methods
+- Preserve custom attributes (`[Async]`, `[NullAllowed]`, etc.)
+
+### 5. Test the Updated Bindings
+
+```bash
+dotnet build -c Release
+dotnet test  # If you have unit tests
+```
+
+Run the sample app to verify functionality.
+
+# Troubleshooting
+
+## Build Errors
+
+### "Framework not found" / "Library not found"
+
+**Causes & Solutions:**
+1. **XCFramework path incorrect** - Verify the path in `<XcodeProject>` or `<NativeReference>`
+2. **Missing architectures** - Ensure xcframework includes arm64 (device) and arm64/x86_64 (simulator)
+3. **CocoaPods not installed** - Run `pod install` in the native directory
+
+```bash
+# Verify xcframework architectures
+lipo -info path/to/Framework.framework/Framework
+```
+
+### "Undefined symbols for architecture"
+
+**Causes & Solutions:**
+1. **Missing linked frameworks** - Add system frameworks to Xcode project's "Link Binary with Libraries"
+2. **Static vs Dynamic mismatch** - Ensure consistent linkage (all static or all dynamic)
+3. **Symbol visibility** - Verify Swift classes/methods are `public` and have `@objc`
+
+```xml
+<!-- Force load symbols if needed -->
+<XcodeProject Include="...">
+  <SchemeName>MyBinding</SchemeName>
+  <ForceLoad>true</ForceLoad>
+  <SmartLink>false</SmartLink>
+</XcodeProject>
+```
+
+### "No type or protocol named..."
+
+**Causes & Solutions:**
+1. **Missing import** - Add required imports to `ApiDefinition.cs` (`using UIKit;`, etc.)
+2. **Protocol vs Interface** - Use interface types (`ICAAnimation` not `CAAnimation`)
+3. **Namespace mismatch** - Verify namespace matches between wrapper and binding
+
+### "Duplicate symbol" / "Symbol already defined"
+
+**Causes & Solutions:**
+1. **Multiple references to same framework** - Check for duplicate `<NativeReference>` entries
+2. **Conflicting dependency versions** - Resolve CocoaPods/SPM version conflicts
+3. **InitWithCoder constructor** - Remove from ApiDefinition.cs (auto-generated by linker)
+
+### Objective Sharpie Errors
+
+**"Unable to find SDK":**
+```bash
+# List available SDKs
+sharpie xcode -sdks
+
+# Update Xcode command line tools
+xcode-select --install
+sudo xcode-select -s /Applications/Xcode.app
+```
+
+**"Parse error in header":**
+- Header may use features Sharpie doesn't support
+- Simplify the Swift wrapper to use basic types
+- Use `--scope=Headers` to limit parsing
+
+## Runtime Errors
+
+### "Native class hasn't been loaded"
+
+**Causes & Solutions:**
+1. **Framework not embedded** - Check that native resources are included in app bundle
+2. **Static library not linked** - Verify `<ForceLoad>true</ForceLoad>` is set
+3. **Missing Objective-C class registration** - Ensure `@objc(ClassName)` annotation is present
+
+### "unrecognized selector sent to instance"
+
+**Causes & Solutions:**
+1. **Selector mismatch** - Verify `[Export("selector:")]` matches Swift `@objc(selector:)` exactly
+2. **Method signature mismatch** - Check parameter count and types match
+3. **Static vs instance method** - Ensure `[Static]` attribute is correct
+
+### "Library not loaded: @rpath/..."
+
+**Causes & Solutions:**
+1. **Swift runtime missing** - Add linker flags for Swift libraries
+2. **Framework not embedded** - Set "Embed & Sign" in Xcode for dynamic frameworks
+3. **rpath not set** - Add `-Wl,-rpath -Wl,@executable_path/Frameworks`
+
+### Callbacks Not Working
+
+**Causes & Solutions:**
+1. **Callback on wrong thread** - Use `DispatchQueue.main.async` in Swift for UI updates
+2. **Callback garbage collected** - Store strong reference to callback handler
+3. **Missing `@escaping`** - Completion handlers must be `@escaping` in Swift
+
+## IntelliSense Issues
+
+**IntelliSense shows errors but project compiles:**
+This is expected behavior. Binding projects don't use source generators. The solution:
+1. Build the binding project first
+2. Reload the solution/project
+3. IntelliSense may still show errors - trust the compiler
+
+# Quick Reference
+
+## ApiDefinition Attributes
+
+| Attribute | Purpose | Example |
+|-----------|---------|---------|
+| `[BaseType(typeof(NSObject))]` | Specifies base class | `[BaseType(typeof(UIView))]` |
+| `[Static]` | Static method/property | `[Static] [Export("shared")]` |
+| `[Export("selector:")]` | Objective-C selector | `[Export("doSomethingWithValue:")]` |
+| `[Async]` | Generate async wrapper | On completion handler methods |
+| `[NullAllowed]` | Nullable parameter/return | `[return: NullAllowed]` |
+| `[Protocol]` | Objective-C protocol | `[Protocol] interface IMyDelegate` |
+| `[Model]` | Protocol implementation | Combined with `[Protocol]` |
+| `[Abstract]` | Required protocol method | In protocol interface |
+| `[Internal]` | Don't expose publicly | Hide helper methods |
+| `[Wrap("...")]` | Wrap with helper | Strongly-typed helpers |
+| `[Sealed]` | Prevent subclassing | On final classes |
+
+## XcodeProject MSBuild Properties
+
+```xml
+<XcodeProject Include="path/to/Project.xcodeproj">
+  <SchemeName>MyScheme</SchemeName>           <!-- Required: Xcode scheme -->
+  <Configuration>Release</Configuration>       <!-- Build configuration -->
+  <Kind>Framework</Kind>                       <!-- Framework or Static -->
+  <SmartLink>true</SmartLink>                  <!-- Enable smart linking -->
+  <ForceLoad>false</ForceLoad>                 <!-- Force load all symbols -->
+</XcodeProject>
+```
+
+## NativeReference MSBuild Properties (Traditional Bindings)
+
+```xml
+<NativeReference Include="Library.xcframework">
+  <Kind>Framework</Kind>                       <!-- Framework or Static -->
+  <Frameworks>Foundation UIKit</Frameworks>    <!-- Required Apple frameworks -->
+  <LinkerFlags>-lsqlite3</LinkerFlags>         <!-- Additional linker flags -->
+  <SmartLink>true</SmartLink>                  <!-- Enable smart linking -->
+  <ForceLoad>false</ForceLoad>                 <!-- Force load all symbols -->
+  <IsCxx>false</IsCxx>                         <!-- C++ library -->
+</NativeReference>
+```
+
+## Common Swift-to-C# Type Mappings
+
+```swift
+// Swift                          // C# ApiDefinition
+String                            string
+String?                           [NullAllowed] string
+Bool                              bool
+Int / Int32                       nint / int
+Int64                             long
+Double                            double
+Float                             float
+Data                              NSData
+[String: Any]                     NSDictionary
+[Any]                             NSArray
+URL                               NSUrl
+Date                              NSDate
+UIView                            UIView
+UIImage                           UIImage
+CGRect                            CGRect
+CGPoint                           CGPoint
+CGSize                            CGSize
+(Result, Error?) -> Void          Action<Result?, NSError?>
+```
+
+# Resources
+
+## Official Documentation
+- [Native Library Interop - .NET Community Toolkit](https://learn.microsoft.com/dotnet/communitytoolkit/maui/native-library-interop)
+- [iOS Binding Project Migration](https://learn.microsoft.com/dotnet/maui/migration/ios-binding-projects)
+- [Binding Objective-C Libraries](https://learn.microsoft.com/xamarin/cross-platform/macios/binding/)
+- [Objective Sharpie](https://learn.microsoft.com/previous-versions/xamarin/cross-platform/macios/binding/objective-sharpie/)
+
+## Tools
+- [XcodeGen](https://github.com/yonaskolb/XcodeGen) - Generate Xcode projects from YAML specification
+
+## Templates and Examples
+- [Maui.NativeLibraryInterop Repository](https://github.com/CommunityToolkit/Maui.NativeLibraryInterop)
+- [CommunityToolkit.Maui Bindings](https://github.com/CommunityToolkit/Maui)
+
+## Related Skills
+- See [docs/ios-bindings-guide.md](../../../docs/ios-bindings-guide.md) for comprehensive reference
+- See [docs/android-bindings-guide.md](../../../docs/android-bindings-guide.md) for Android bindings
+
+# Appendix A: Using the Community Toolkit Template (Alternative)
+
+If you prefer to start from an existing template rather than creating from scratch:
+
+```bash
+git clone https://github.com/CommunityToolkit/Maui.NativeLibraryInterop
+cp -r Maui.NativeLibraryInterop/template ./MyBinding
+cd MyBinding
+
+# Rename files and update references
+find . -name "*NewBinding*" -exec bash -c 'mv "$0" "${0//NewBinding/MyBinding}"' {} \;
+find . -type f \( -name "*.cs" -o -name "*.csproj" -o -name "*.swift" -o -name "*.yml" \) | xargs sed -i '' 's/NewBinding/MyBinding/g'
+```
+
+The template includes pre-configured:
+- Xcode project with correct build settings
+- Binding .csproj with XcodeProject reference
+- Sample MAUI app
+- GitHub Actions CI/CD workflows
+
+# Output Format
+
+When assisting with iOS slim bindings, provide:
+
+1. **Project structure** - File/folder layout for the binding
+2. **Swift wrapper code** - Complete `DotnetMyBinding.swift` implementation
+3. **Xcode configuration** - Build settings and dependency setup
+4. **C# binding project** - `.csproj` and `ApiDefinition.cs` files
+5. **Usage examples** - How to call the binding from MAUI/C#
+6. **Troubleshooting guidance** - Common issues and solutions for the specific library
+
+Always verify:
+- Swift classes have `@objc(ClassName)` annotations
+- Methods have `@objc(selector:)` annotations matching Objective-C conventions
+- Types are marshallable between Swift and C#
+- Async operations use completion handlers with `[Async]` attribute
+- Error handling uses `NSError` for proper propagation

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,171 @@
+# Repository Instructions for Plugin.RevenueCat
+
+## Project Overview
+
+This is a .NET MAUI plugin providing RevenueCat integration using a **slim binding approach**. The library binds RevenueCat's native iOS/macCatalyst and Android SDKs in a way that minimizes the binding surface area and simplifies maintenance.
+
+## Architecture: Slim Bindings Approach
+
+### Philosophy
+
+Rather than creating complete 1:1 bindings of the native RevenueCat SDKs (which would be complex, brittle, and difficult to maintain), this project uses a "slim binding" approach:
+
+1. **Native Wrapper Libraries**: We create small native library projects (Swift for iOS/macCatalyst, Java for Android) that expose a simplified API surface
+2. **JSON-Based Data Transfer**: The native wrappers return JSON strings for complex data types, which are then deserialized into shared .NET models
+3. **Unified Cross-Platform Models**: The `Plugin.RevenueCat.Core` project contains shared model classes (e.g., `CustomerInfo`, `Offering`, `Subscriber`) that work across all platforms
+4. **Minimal Binding Surface**: The bound APIs only deal with simple types (strings, bools, callbacks) making the bindings trivial to maintain
+
+### Key Benefits
+
+- **Easy to Update**: When RevenueCat releases new SDK versions, updating is straightforward
+- **Cross-Platform Consistency**: JSON serialization ensures iOS and Android return identical data structures
+- **Reduced Complexity**: No need to bind hundreds of native types - just a handful of methods
+- **Maintainability**: The native wrapper code is simple and easy to debug
+
+## Project Structure
+
+### Native Projects
+
+- **iOS/macCatalyst**: `macios/native/RevenueCatBinding/` - Xcode project with Swift wrapper
+  - `RevenueCatBinding.swift` - The slim binding wrapper that converts RevenueCat SDK calls to JSON responses
+  
+- **Android**: `android/native/revenuecatbinding/` - Gradle project with Java wrapper
+  - `RevenueCatManager.java` - The slim binding wrapper that converts RevenueCat SDK calls to JSON responses
+
+### Binding Projects
+
+- **iOS/macCatalyst Binding**: `macios/RevenueCat.MaciOS.Binding/`
+  - `RevenueCat.MaciOS.Binding.csproj` - References the Xcode project and native xcframework
+  - `ApiDefinition.cs` - Objective-C binding definitions for the Swift wrapper
+  
+- **Android Binding**: `android/RevenueCat.Android.Binding/`
+  - `RevenueCat.Android.Binding.csproj` - References the Gradle project and Maven dependencies
+
+### Core Libraries
+
+- **Plugin.RevenueCat.Core**: Shared models and converters for JSON deserialization
+- **Plugin.RevenueCat**: Main MAUI plugin with `IRevenueCatManager` interface
+- **Plugin.RevenueCat.Api**: REST API clients for RevenueCat Web API V1 and V2
+
+### Web API Usage
+
+Some operations are performed via RevenueCat's REST APIs rather than the native SDKs:
+
+- `IRevenueCatApiV1` - V1 API for subscriber and offerings retrieval
+- `IRevenueCatApiV2` - V2 API for customer management and attributes
+
+Use these APIs when you need server-side operations or when the native SDK doesn't expose certain functionality.
+
+---
+
+## Updating Native SDK Versions
+
+### Finding Latest Versions
+
+1. **iOS/macCatalyst SDK**: Check [RevenueCat purchases-ios releases](https://github.com/RevenueCat/purchases-ios/releases)
+2. **Android SDK**: Check [Maven Central for purchases](https://repo1.maven.org/maven2/com/revenuecat/purchases/purchases/) or [RevenueCat purchases-android releases](https://github.com/RevenueCat/purchases-android/releases)
+
+### Updating iOS/macCatalyst Bindings
+
+1. **Update the version** in `macios/RevenueCat.MaciOS.Binding/RevenueCat.MaciOS.Binding.csproj`:
+   ```xml
+   <Target Name="DownloadNativeDependencies" ...>
+       <PropertyGroup>
+           <RevenueCatSdkVersion>5.48.0</RevenueCatSdkVersion>  <!-- Update this -->
+       </PropertyGroup>
+   </Target>
+   ```
+
+2. **Update Xcode project references** if the RevenueCat SDK has API changes:
+   - Open `macios/native/RevenueCatBinding/RevenueCatBinding.xcodeproj` in Xcode
+   - Verify the RevenueCat package dependency version
+   - Update `RevenueCatBinding.swift` if there are breaking API changes
+
+3. **Download new dependencies**:
+   ```bash
+   dotnet build -m:1 -t:DownloadNativeDependencies ./macios/RevenueCat.MaciOS.Binding/RevenueCat.MaciOS.Binding.csproj
+   ```
+
+4. **Update binding definitions** in `ApiDefinition.cs` if the wrapper API surface changed
+
+### Updating Android Bindings
+
+1. **Update the SDK version** in `android/RevenueCat.Android.Binding/RevenueCat.Android.Binding.csproj`:
+   ```xml
+   <PropertyGroup>
+       <RevenueCatSdkVersion>9.5.0</RevenueCatSdkVersion>  <!-- Update this -->
+   </PropertyGroup>
+   ```
+
+2. **Update the Gradle project** in `android/native/revenuecatbinding/build.gradle.kts`:
+   ```kotlin
+   dependencies {
+       implementation("com.revenuecat.purchases:purchases:9.5.0")  // Update this
+       implementation("com.revenuecat.purchases:purchases-store-amazon:9.5.0")  // Update this
+   }
+   ```
+
+3. **Re-evaluate the native dependency graph** (see section below)
+
+4. **Update `RevenueCatManager.java`** if there are breaking API changes in the native SDK
+
+### Re-evaluating the Android Dependency Graph
+
+**Important**: The Android dependency graph can change significantly between RevenueCat SDK releases. You must verify and update dependencies when upgrading.
+
+1. **Check for new transitive dependencies**:
+   - Review RevenueCat's release notes for dependency changes
+   - Run a Gradle dependency report: `./gradlew dependencies` in the `android/native/` directory
+
+2. **Update `AndroidMavenLibrary` references** in `RevenueCat.Android.Binding.csproj`:
+   ```xml
+   <ItemGroup>
+       <AndroidMavenLibrary Include="com.revenuecat.purchases:purchases" Version="$(RevenueCatSdkVersion)" ... />
+       <AndroidMavenLibrary Include="com.revenuecat.purchases:purchases-store-amazon" Version="$(RevenueCatSdkVersion)" ... />
+       <!-- Add/update other dependencies as needed -->
+   </ItemGroup>
+   ```
+
+3. **Update NuGet package references** if Xamarin/AndroidX bindings need updates:
+   ```xml
+   <ItemGroup>
+       <PackageReference Include="Xamarin.Android.Google.BillingClient" />
+       <PackageReference Include="Xamarin.KotlinX.Serialization.Json" />
+       <!-- etc. -->
+   </ItemGroup>
+   ```
+
+4. **Update `AndroidIgnoredJavaDependency`** items for any dependencies that should be satisfied by NuGet packages rather than Maven
+
+5. **Version alignment**: Ensure Kotlin, AndroidX, and Google Play Services versions are compatible across all dependencies. Check `Directory.packages.props` for centralized version management.
+
+---
+
+## Build Commands
+
+```bash
+# Build everything
+dotnet build RevenueCat.sln
+
+# Download iOS native dependencies
+dotnet build -m:1 -t:DownloadNativeDependencies ./macios/RevenueCat.MaciOS.Binding/RevenueCat.MaciOS.Binding.csproj
+
+# Run tests
+dotnet test ./Tests/Tests.csproj
+```
+
+## Testing
+
+- Unit tests are in the `Tests/` directory
+- JSON parsing tests validate that model deserialization works correctly across platforms
+- Sample app in `sample/` can be used for manual testing
+
+## Key Files to Know
+
+| File | Purpose |
+|------|---------|
+| `macios/native/RevenueCatBinding/RevenueCatBinding/RevenueCatBinding.swift` | iOS/macCatalyst slim binding wrapper |
+| `android/native/revenuecatbinding/src/main/java/.../RevenueCatManager.java` | Android slim binding wrapper |
+| `Plugin.RevenueCat.Core/Models/` | Shared cross-platform data models |
+| `Plugin.RevenueCat/IRevenueCatManager.cs` | Main plugin interface |
+| `Plugin.RevenueCat/Platforms/` | Platform-specific implementations |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,17 +76,23 @@ Use these APIs when you need server-side operations or when the native SDK doesn
    </Target>
    ```
 
-2. **Update Xcode project references** if the RevenueCat SDK has API changes:
+2. **Validate API changes** before proceeding:
+   - Check RevenueCat iOS SDK release notes for breaking changes between versions
+   - Review `macios/native/RevenueCatBinding/RevenueCatBinding/RevenueCatBinding.swift` to identify which SDK APIs are used
+   - Verify those APIs haven't changed signatures or been removed
+   - If wrapper uses changed APIs, update the Swift wrapper accordingly
+
+3. **Update Xcode project references** if the RevenueCat SDK has API changes:
    - Open `macios/native/RevenueCatBinding/RevenueCatBinding.xcodeproj` in Xcode
    - Verify the RevenueCat package dependency version
    - Update `RevenueCatBinding.swift` if there are breaking API changes
 
-3. **Download new dependencies**:
+4. **Download new dependencies**:
    ```bash
    dotnet build -m:1 -t:DownloadNativeDependencies ./macios/RevenueCat.MaciOS.Binding/RevenueCat.MaciOS.Binding.csproj
    ```
 
-4. **Update binding definitions** in `ApiDefinition.cs` if the wrapper API surface changed
+5. **Update binding definitions** in `ApiDefinition.cs` only if the wrapper's `@objc` exposed interface changed (new methods, changed signatures, etc.)
 
 ### Updating Android Bindings
 
@@ -105,9 +111,15 @@ Use these APIs when you need server-side operations or when the native SDK doesn
    }
    ```
 
-3. **Re-evaluate the native dependency graph** (see section below)
+3. **Validate API changes** before proceeding:
+   - Check RevenueCat Android SDK release notes for breaking changes between versions
+   - Review `android/native/revenuecatbinding/src/main/java/.../RevenueCatManager.java` to identify which SDK APIs are used
+   - Verify those APIs haven't changed signatures or been removed
+   - If wrapper uses changed APIs, update the Java wrapper accordingly
 
-4. **Update `RevenueCatManager.java`** if there are breaking API changes in the native SDK
+4. **Re-evaluate the native dependency graph** (see section below)
+
+5. **Update `RevenueCatManager.java`** if there are breaking API changes in the native SDK
 
 ### Re-evaluating the Android Dependency Graph
 

--- a/android/RevenueCat.Android.Binding/RevenueCat.Android.Binding.csproj
+++ b/android/RevenueCat.Android.Binding/RevenueCat.Android.Binding.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<RevenueCatSdkVersion>9.5.0</RevenueCatSdkVersion>
+		<RevenueCatSdkVersion>9.19.1</RevenueCatSdkVersion>
 		<RevenueCatSdkUrl>https://repo1.maven.org/maven2/com/revenuecat/purchases/purchases/$(RevenueCatSdkVersion)/purchases-$(RevenueCatSdkVersion).aar</RevenueCatSdkUrl>
 		<RevenueCatUISdkUrl>https://repo1.maven.org/maven2/com/revenuecat/purchases/purchases-ui/$(RevenueCatSdkVersion)/purchases-ui-$(RevenueCatSdkVersion).aar</RevenueCatUISdkUrl>
 	</PropertyGroup>

--- a/android/native/revenuecatbinding/build.gradle.kts
+++ b/android/native/revenuecatbinding/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
     // Uncomment line below and replace {dependency.name.goes.here} with your dependency
     // implementation("{dependency.name.goes.here}")
 
-    implementation("com.revenuecat.purchases:purchases:9.5.0")
-    implementation("com.revenuecat.purchases:purchases-store-amazon:9.5.0")
+    implementation("com.revenuecat.purchases:purchases:9.19.1")
+    implementation("com.revenuecat.purchases:purchases-store-amazon:9.19.1")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3")
 //    implementation("com.revenuecat.purchases:purchases-ui:8.16.0")
     implementation("com.google.code.gson:gson:2.12.0")

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
 	"sdk": {
-		"version": "10.0.100",
+		"version": "10.0.101",
 		"rollForward": "latestMinor",
-		"workloadVersion": "10.0.100.1"
+		"workloadVersion": "10.0.101.1"
 	}
 }

--- a/macios/RevenueCat.MaciOS.Binding/RevenueCat.MaciOS.Binding.csproj
+++ b/macios/RevenueCat.MaciOS.Binding/RevenueCat.MaciOS.Binding.csproj
@@ -121,7 +121,7 @@
 	
 	<Target Name="DownloadNativeDependencies" BeforeTargets="Build" Condition=" '$(IsCrossTargetingBuild)' == 'true' ">
 		<PropertyGroup>
-			<RevenueCatSdkVersion>5.48.0</RevenueCatSdkVersion>
+			<RevenueCatSdkVersion>5.55.2</RevenueCatSdkVersion>
 
 			<RevenueCatSdkUrl>https://github.com/RevenueCat/purchases-ios/releases/download/$(RevenueCatSdkVersion)/RevenueCat.xcframework.zip</RevenueCatSdkUrl>
 			


### PR DESCRIPTION
This pull request updates the plugin to use the latest RevenueCat SDKs for both Android and iOS/macCatalyst, and provides comprehensive documentation on the slim binding approach and upgrade process. The most important changes include SDK version bumps, dependency updates, and the addition of detailed project instructions.

**SDK Version Upgrades:**

* Android: Updated `RevenueCatSdkVersion` from `9.5.0` to `9.19.1` in `RevenueCat.Android.Binding.csproj` and updated Gradle dependencies to match the new version. [[1]](diffhunk://#diff-54715f5fc35193eee02d3c6f391e4084a7df8c4d15600c1ebdfa47689f063506L18-R18) [[2]](diffhunk://#diff-d29fb19f7e7a30bab0b5c468138987f28bb4b0284f127083f90d049dfb92a769L34-R35)
* iOS/macCatalyst: Updated `RevenueCatSdkVersion` from `5.48.0` to `5.55.2` in `RevenueCat.MaciOS.Binding.csproj`.

**Dependency and Tooling Updates:**

* Updated .NET SDK version in `global.json` from `10.0.100` to `10.0.101` to ensure compatibility with the latest tooling.

**Documentation Improvements:**

* Added a new `.github/copilot-instructions.md` file that explains the slim binding architecture, project structure, how to update native SDKs, and key files for maintainers. This documentation will help onboard new contributors and clarify the update process.