### PR TITLE
Add Android & iOS slim-binding skills and refs

### DIFF
--- a/.claude/skills/android-slim-bindings/SKILL.md
+++ b/.claude/skills/android-slim-bindings/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: android-slim-bindings
+description: Create and update slim/native platform interop bindings for Android in .NET MAUI and .NET for Android projects. Guides through creating Java/Kotlin wrappers, configuring Gradle projects, resolving Maven dependencies, generating C# bindings, and integrating native Android libraries using the Native Library Interop (NLI) approach. Use when asked about Android bindings, AAR/JAR integration, Kotlin interop, Maven dependencies, or bridging native Android SDKs to .NET.
+---
+
+# When to use this skill
+
+Activate this skill when the user asks:
+- How do I create Android bindings for a native library?
+- How do I wrap an Android SDK for use in .NET MAUI?
+- How do I create slim bindings for Android?
+- How do I use Native Library Interop for Android?
+- How do I bind a Kotlin library to .NET?
+- How do I bind a Java library to .NET?
+- How do I integrate an AAR or JAR into .NET MAUI?
+- How do I create a Java/Kotlin wrapper for a native Android library?
+- How do I update Android bindings when the native SDK changes?
+- How do I fix Android binding build errors?
+- How do I expose native Android APIs to C#?
+- How do I resolve Maven dependencies for Android bindings?
+- How do I handle AndroidX dependencies in bindings?
+- How do I fix "Java dependency is not satisfied" errors?
+- How do I use AndroidMavenLibrary in my binding project?
+
+# Overview
+
+This skill guides the creation of **Native Library Interop (Slim Bindings)** for Android. This modern approach creates a thin native Java/Kotlin wrapper exposing only the APIs you need from a native Android library, making bindings easier to create and maintain.
+
+## When to Use Slim Bindings vs Traditional Bindings
+
+| Scenario | Recommended Approach |
+|----------|---------------------|
+| Need only a subset of library functionality | **Slim Bindings** |
+| Easier maintenance when SDK updates | **Slim Bindings** |
+| Prefer working in Java/Kotlin for wrapper | **Slim Bindings** |
+| Better isolation from breaking changes | **Slim Bindings** |
+| Complex libraries with many dependencies | **Slim Bindings** |
+| Need entire library API surface | Traditional Bindings |
+| Creating bindings for third-party developers | Traditional Bindings |
+| Already maintaining traditional bindings | Traditional Bindings |
+
+# Inputs
+
+| Parameter | Required | Example | Notes |
+|-----------|----------|---------|-------|
+| libraryName | yes | `FirebaseMessaging`, `OkHttp` | Name of the native Android library to bind |
+| bindingProjectName | yes | `MyBinding.Android` | Name for the C# binding project |
+| dependencySource | no | `maven`, `aar`, `jar` | How the native library is distributed |
+| targetFrameworks | no | `net9.0-android` | Target frameworks (default: latest .NET Android) |
+| exposedApis | no | List of specific APIs | Which native APIs to expose (helps scope the wrapper) |
+| mavenCoordinates | no | `com.example:library:1.0.0` | Maven coordinates if library is from Maven repository |
+
+# Project Structure
+
+```
+MyBinding/
+ android/
+ native/                              # Android Studio/Gradle project   
+ app/      
+ src/main/         
+ java/com/example/mybinding/            
+ DotnetMyBinding.java  # Java wrapper implementation                
+ kotlin/com/example/mybinding/            
+ DotnetMyBinding.kt    # Or Kotlin wrapper                
+ build.gradle.kts         
+ settings.gradle.kts      
+ build.gradle.kts      
+ MyBinding.Android.Binding/   
+ MyBinding.Android.Binding.csproj       
+ Transforms/       
+ Metadata.xml           
+ sample/
+ MauiSample/                          # Sample MAUI app   
+ MauiSample.csproj       
+ MainPage.xaml.cs       
+ README.md
+```
+
+# Step-by-step Process
+
+> **For detailed code examples and full implementation walkthroughs, see [references/android-slim-bindings-implementation.md](references/android-slim-bindings-implementation.md).**
+
+## Step 1: Analyze Dependencies First
+
+Before creating any bindings, analyze the complete dependency tree of your target library. This is the most critical step and where most binding projects fail.
+
+**Prerequisites:** JDK 17+, Android SDK with `ANDROID_HOME` set, .NET SDK 9+. You don't need Gradle installed globally; the Gradle Wrapper downloads the correct version automatically.
+
+## Step 2: Create the Android Library Project
+
+Choose one of these approaches:
+
+- **Option A: Android Studio** (recommended for GUI-based projects: create a "No Activity" project, then add an Android Library module)
+- **Option B: `gradle init` with Wrapper** (recommended for CLI-based projects: scaffold with Gradle using the Wrapper, then convert to an Android library)
+- **Option C: CommunityToolkit NativeLibraryInterop template** (clone and use the CommunityToolkit NativeLibraryInterop template as your starting point)
+- **Option D: Manual creation with Gradle Wrapper** (create the project structure manually using the Gradle Wrapper)
+
+After project creation, configure `settings.gradle.kts`, root `build.gradle.kts`, and `app/build.gradle.kts` with your library dependency.
+
+## Step 3: Analyze the Full Dependency Tree
+
+```bash
+./gradlew app:dependencies --configuration releaseRuntimeClasspath
+```
+
+ resolution strategy.
+
+**Understanding the output:** `->` = version conflict resolution, `(*)` = deduplication, `(c)` = constraint.
+
+## Step 4: Create the Wrapper Class
+
+Create a Java or Kotlin wrapper in `app/src/main/java/` (or `kotlin/`) that exposes only the APIs you need. Key guidelines:
+
+- Use simple, marshallable types (String, boolean, int, byte[], Context, View)
+- Use callback interfaces for async operations (not Kotlin coroutines or lambdas)
+- Prefix class names with `Dotnet` for clarity
+- Add `@JvmStatic` on all Kotlin methods for static access from C#
+- Use `object` in Kotlin for singleton pattern
+
+## Step 5: Build the AAR
+
+```bash
+./gradlew :app:assembleRelease
+# Output: app/build/outputs/aar/app-release.aar
+```
+
+## Step 6: Create the C# Binding Project
+
+```bash
+dotnet new androidbinding -n MyBinding.Android.Binding
+```
+
+Key `.csproj` elements:
+- `< reference the built AARAndroidLibrary>` 
+- `< NuGet packages for transitive dependenciesPackageReference>` 
+- `<AndroidMavenLibrary Bind=" Maven deps without NuGet equivalentfalse">` 
+- `< compile-time only dependenciesAndroidIgnoredJavaDependency>` 
+
+Configure `Transforms/Metadata.xml` for namespace renaming and parameter names.
+
+## Step 7: Resolve Dependencies
+
+Build and resolve XA4241/XA4242 errors using this decision tree:
+
+```
+For each unsatisfied dependency:
+
+ Is there a XA4242 suggestion?
+ Install the suggested NuGet package
+
+ Is the dependency needed from C#?
+ Find/create a binding NuGet or create your own binding
+ Use AndroidMavenLibrary with Bind="false"
+
+ Is it a compile-time only dependency (annotations, processors)?
+ Use AndroidIgnoredJavaDependency
+
+ Create a separate binding project or include AAR/JAR directly
+```
+
+### Common Maven-to-NuGet Mappings
+
+| Maven Artifact | NuGet Package |
+|----------------|---------------|
+| `androidx.annotation:annotation` | `Xamarin.AndroidX.Annotation` |
+| `androidx.core:core` | `Xamarin.AndroidX.Core` |
+| `androidx.core:core-ktx` | `Xamarin.AndroidX.Core.Core.Ktx` |
+| `androidx.appcompat:appcompat` | `Xamarin.AndroidX.AppCompat` |
+| `androidx.fragment:fragment` | `Xamarin.AndroidX.Fragment` |
+| `androidx.activity:activity` | `Xamarin.AndroidX.Activity` |
+| `androidx.recyclerview:recyclerview` | `Xamarin.AndroidX.RecyclerView` |
+| `androidx.lifecycle:lifecycle-common` | `Xamarin.AndroidX.Lifecycle.Common` |
+| `org.jetbrains.kotlin:kotlin-stdlib` | `Xamarin.Kotlin.StdLib` |
+| `org.jetbrains.kotlinx:kotlinx-coroutines-core` | `Xamarin.KotlinX.Coroutines.Core` |
+| `com.google.android.material:material` | `Xamarin.Google.Android.Material` |
+| `com.squareup.okhttp3:okhttp` | `Square.OkHttp3` |
+| `com.google.code.gson:gson` | `GoogleGson` |
+
+### Finding NuGet Packages
+
+```bash
+dotnet package search "artifact=androidx.core:core" --source https://api.nuget.org/v3/index.json
+```
+
+## Step 8: Customize Bindings with Metadata
+
+Edit `Transforms/Metadata.xml` to rename packages, classes, parameters, and remove internal types. Examine `obj/Debug/net9.0-android/api.xml` after building to construct correct XPath expressions.
+
+## Step 9: Build and Verify
+
+```bash
+dotnet build -c Release
+```
+
+## Step 10: Use in Your MAUI App
+
+Add a conditional `<ProjectReference>`, initialize in `MauiProgram.cs` using `ConfigureLifecycleEvents`, and implement callback interfaces by extending `Java.Lang.Object`.
+
+# Updating Bindings When Native SDK Changes
+
+1. Update native dependency version in `app/build.gradle.kts`
+2. Re-analyze dependencies with `./gradlew app:dependencies`
+3. Update the Java/Kotlin wrapper if APIs changed
+4. Rebuild the AAR with `./gradlew :app:assembleRelease`
+5. Update NuGet packages and Maven dependencies in binding `.csproj`
+6. Rebuild C# binding and fix any new XA4241/XA4242 errors
+7. Update `Metadata.xml` for new classes/methods
+8. Test with sample app
+
+> For detailed update instructions, see [references/android-slim-bindings-implementation.md](references/android-slim-bindings-implementation.md).
+
+# Troubleshooting
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| XA4241 / XA4242 | Missing transitive dependency | Use NuGet, `AndroidMavenLibrary Bind="false"`, or `AndroidIgnoredJavaDependency` |
+| "Type is defined multiple times" | Duplicate dependency | Check NuGet/AAR overlap, use `Bind="false"` |
+| "Class does not implement interface member" | Covariant return types | Add custom implementation in `Additions/` folder |
+| "Cannot find symbol" | Missing Gradle dependency | Verify `build.gradle.kts` dependencies, rebuild AAR |
+| `NoClassDefFoundError` (runtime) | Dependency ignored incorrectly | Remove from `AndroidIgnoredJavaDependency`, satisfy properly |
+| `UnsatisfiedLinkError` (runtime) | Missing .so native library | Include via `<AndroidNativeLibrary>`, check ABI compatibility |
+| Callback not invoked | Wrong thread / GC'd reference | Use `MainThread.BeginInvokeOnMainThread()`, hold strong reference |
+
+> For detailed troubleshooting with code examples, see [references/android-slim-bindings-implementation.md](references/android-slim-bindings-implementation.md).
+
+# Quick Reference
+
+## Type Mapping
+
+| Java/Kotlin Type | C# Type | Notes |
+|------------------|---------|-------|
+| `String` | `string` | Direct mapping |
+| `boolean` / `Boolean` | `bool` | Direct mapping |
+| `int` / `Integer` | `int` | Direct mapping |
+| `long` / `Long` | `long` | Direct mapping |
+| `double` / `Double` | `double` | Direct mapping |
+| `float` / `Float` | `float` | Direct mapping |
+| `byte[]` | `byte[]` | Direct mapping |
+| `Context` | `Android.Content.Context` | Pass from platform |
+| `View` | `Android.Views.View` | For view creation |
+| `JSONObject` | `Org.Json.JSONObject` | For complex data |
+| Callback interface | `IJavaObject` implementation | See callback pattern |
+
+## Things to Avoid in Wrapper API
+
+| Avoid | Use Instead |
+|-------|-------------|
+| Kotlin coroutines | Callback interfaces |
+| Kotlin lambdas | Java-style interfaces |
+| Kotlin data classes | Simple classes with getters |
+| Kotlin sealed classes | Enums or class hierarchy |
+| Generics (complex) | Specific types or Object |
+| Rx/Flow observables | Callback interfaces |
+
+## MSBuild Items Reference
+
+| Item | Purpose |
+|------|---------|
+| `<AndroidLibrary>` | Include AAR/JAR in binding |
+| `<AndroidMavenLibrary>` | Download and include from Maven |
+| `<AndroidIgnoredJavaDependency>` | Ignore a dependency (compile-time only) |
+| `<AndroidNativeLibrary>` | Include .so files |
+| `<TransformFile>` | Metadata transform files |
+| `<PackageReference>` | NuGet package reference |
+
+## Common Attributes
+
+| Attribute | Values | Purpose |
+|-----------|--------|---------|
+| `Bind` | `true`/`false` | Whether to generate C# bindings |
+| `Pack` | `true`/`false` | Whether to include in NuGet package |
+| `JavaArtifact` | `groupId:artifactId` | Declare what Maven artifact this satisfies |
+| `JavaVersion` | `version` | Version of the Maven artifact |
+| `Repository` | `Central`/`Google`/URL | Maven repository to download from |
+
+# Resources
+
+## Official Documentation
+- [Binding a Java Library (Microsoft Docs)](https://learn.microsoft.com/dotnet/android/binding-libs/binding-java-libs/binding-java-library)
+- [Binding from Maven (Microsoft Docs)](https://learn.microsoft.com/dotnet/android/binding-libs/binding-java-libs/binding-java-maven-library)
+- [Java Dependency Verification](https://learn.microsoft.com/dotnet/android/binding-libs/advanced-concepts/java-dependency-verification)
+- [Resolving Java Dependencies](https://learn.microsoft.com/dotnet/android/binding-libs/advanced-concepts/resolving-java-dependencies)
+- [Java Bindings Metadata](https://learn.microsoft.com/dotnet/android/binding-libs/customizing-bindings/java-bindings-metadata)
+- [Native Library Interop - .NET Community Toolkit](https://learn.microsoft.com/dotnet/communitytoolkit/maui/native-library-interop)
+
+## Version Discovery
+- [Android Gradle Plugin Releases](https://developer.android.com/build/releases/gradle-plugin)
+- [Gradle Releases](https://gradle.org/releases/)
+- [Kotlin Releases](https://kotlinlang.org/docs/releases.html)
+
+## Templates and Examples
+- [Maui.NativeLibraryInterop Repository](https://github.com/CommunityToolkit/Maui.NativeLibraryInterop)
+- [Xamarin.AndroidX Repository](https://github.com/xamarin/AndroidX)
+
+## Reference Files
+- [android-bindings-guide.md](references/android-bindings-guide.md) — comprehensive binding reference
+- [android-slim-bindings-implementation.md](references/android-slim-bindings-implementation.md) — detailed code examples, troubleshooting, and complete scripts
+- For iOS bindings, use the **ios-slim-bindings** skill
+
+# Output Format
+
+When assisting with Android slim bindings, provide:
+
+1. **Dependency analysis** - Full dependency tree and NuGet mapping strategy
+2. **Project structure** - File/folder layout for the binding
+3. **Wrapper code** - Complete Java or Kotlin implementation
+4. **Gradle configuration** - build.gradle.kts with dependencies
+5. **C# binding project** - `.csproj` with proper dependency references
+6. **Metadata transforms** - Metadata.xml for namespace and parameter renaming
+7. **Usage examples** - How to call the binding from MAUI/C#
+8. **Troubleshooting guidance** - Common issues and solutions for the specific library
+
+Always verify:
+- All transitive dependencies are accounted for
+- NuGet packages match required Maven versions
+- Wrapper methods use simple, marshallable types
+- Callback interfaces are properly designed
+- Metadata.xml renames parameters to meaningful names

--- a/.claude/skills/android-slim-bindings/references/android-bindings-guide.md
+++ b/.claude/skills/android-slim-bindings/references/android-bindings-guide.md
@@ -1,0 +1,1136 @@
+# Creating Bindings for .NET Android Projects
+
+This guide covers the process of creating C# bindings to interface with native Android libraries (AAR/JAR files) in .NET MAUI, and .NET for Android projects. Special emphasis is placed on resolving the complex dependency graphs that are common with Android libraries.
+
+## Overview
+
+When you need to use a third-party Android library not written in C#, you must create a **binding** that wraps the Java/Kotlin code with C# Managed Callable Wrappers (MCW). There are two primary approaches:
+
+1. **Traditional Full Bindings** - Bind the entire native library's API surface automatically
+2. **Native Library Interop (Slim Bindings)** - Create a thin Java/Kotlin wrapper exposing only the APIs you need
+
+---
+
+## Understanding Android Library Dependencies
+
+Before diving into binding approaches, it's critical to understand how Android dependencies work, as this is the most challenging aspect of Android bindings.
+
+### The Dependency Challenge
+
+Android libraries commonly depend on:
+- **AndroidX libraries** - Google's modern support libraries
+- **Kotlin Standard Library** - Required for any Kotlin-based library
+- **Google Play Services** - For Firebase, Maps, Auth, etc.
+- **Third-party libraries** - OkHttp, Retrofit, Gson, etc.
+
+These dependencies form a **transitive dependency graph** that must be satisfied, or your app will crash at runtime with `Java.Lang.NoClassDefFoundError`.
+
+### How Dependencies Are Declared
+
+Android libraries declare dependencies in their **POM file** (Project Object Model), which lists:
+- Required dependencies with minimum versions
+- Optional dependencies
+- Compile-time only dependencies (annotations, etc.)
+
+### Analyzing the Full Dependency Graph
+
+Before creating bindings, you need to understand the complete transitive dependency tree of your target library. There are several ways to obtain this information.
+
+#### Method 1: Using Gradle Dependencies Task
+
+The most comprehensive way to see the full dependency tree is to create a minimal Gradle project and use the `dependencies` task.
+
+**Step 1: Create a minimal `build.gradle.kts`:**
+
+```kotlin
+plugins {
+    id("java-library")
+}
+
+repositories {
+    google()
+    mavenCentral()
+    // Add other repositories as needed
+    maven { url = uri("https://jitpack.io") }
+}
+
+dependencies {
+    // Add the library you want to analyze
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+}
+```
+
+**Step 2: Run the dependencies task:**
+
+```bash
+gradle dependencies --configuration runtimeClasspath
+```
+
+This produces a tree showing all transitive dependencies:
+
+```
+runtimeClasspath
+\--- com.squareup.okhttp3:okhttp:4.12.0
+     +--- com.squareup.okio:okio:3.6.0
+     |    \--- com.squareup.okio:okio-jvm:3.6.0
+     |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 -> 1.9.21
+     |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.21
+     |         |    |    \--- org.jetbrains:annotations:13.0
+     |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.21
+     |         |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.21 (*)
+     |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.21 -> 1.9.21
+     \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 -> 1.9.21 (*)
+```
+
+**Understanding the output:**
+- `->` indicates version conflict resolution (e.g., `1.9.10 -> 1.9.21` means 1.9.10 was requested but 1.9.21 was resolved)
+- `(*)` indicates the dependency was already shown elsewhere in the tree (deduplication)
+
+**Step 3: Get a flat list of resolved dependencies:**
+
+```bash
+gradle dependencies --configuration runtimeClasspath | grep -E "^[+\\\\]" | sed 's/.*--- //' | sort -u
+```
+
+Or use the `dependencyInsight` task for a specific dependency:
+
+```bash
+gradle dependencyInsight --dependency kotlin-stdlib --configuration runtimeClasspath
+```
+
+#### Method 2: Using Maven Dependency Plugin
+
+If you prefer Maven, create a minimal `pom.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <groupId>com.example</groupId>
+    <artifactId>dependency-analyzer</artifactId>
+    <version>1.0.0</version>
+    
+    <repositories>
+        <repository>
+            <id>google</id>
+            <url>https://maven.google.com</url>
+        </repository>
+    </repositories>
+    
+    <dependencies>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.12.0</version>
+        </dependency>
+    </dependencies>
+</project>
+```
+
+**Get the dependency tree:**
+
+```bash
+mvn dependency:tree
+```
+
+**Get resolved versions only (flat list):**
+
+```bash
+mvn dependency:list
+```
+
+**Resolve and display effective versions:**
+
+```bash
+mvn dependency:resolve
+```
+
+#### Method 3: Inspecting POM Files Directly
+
+For quick analysis, you can read POM files directly from Maven Central or Google's Maven repository:
+
+```bash
+# Maven Central
+curl -s "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/4.12.0/okhttp-4.12.0.pom"
+
+# Google Maven (AndroidX)
+curl -s "https://maven.google.com/androidx/core/core/1.12.0/core-1.12.0.pom"
+```
+
+#### Understanding Version Constraints
+
+When analyzing dependencies, pay attention to version constraints in POM files:
+
+| Constraint | Meaning |
+|------------|---------|
+| `1.0.0` | Recommended version (soft requirement) |
+| `[1.0.0]` | Exact version required |
+| `[1.0.0,)` | Version 1.0.0 or higher |
+| `[1.0.0,2.0.0)` | Between 1.0.0 (inclusive) and 2.0.0 (exclusive) |
+| `(,1.0.0]` | Any version up to and including 1.0.0 |
+
+Gradle resolves conflicts by selecting the **highest** version requested across the dependency graph by default.
+
+### Finding NuGet Packages for Maven Dependencies
+
+Once you have your dependency list, you need to find corresponding NuGet packages. Here's how to search effectively.
+
+#### Searching NuGet.org
+
+**Using the NuGet CLI:**
+
+```bash
+# Search for packages related to AndroidX Core
+nuget search "Xamarin.AndroidX.Core"
+
+# Search using dotnet CLI
+dotnet package search "Xamarin.AndroidX"
+```
+
+**Using the NuGet API directly:**
+
+```bash
+# Search for packages containing "androidx.core"
+curl -s "https://azuresearch-usnc.nuget.org/query?q=androidx.core&take=20" | jq '.data[] | {id: .id, version: .version}'
+```
+
+#### Microsoft-Maintained Package Tags
+
+Microsoft maintains NuGet bindings for many common Android libraries (AndroidX, Kotlin, Google Play Services, Firebase). These packages include special tags that help identify which Maven artifact they satisfy:
+
+| Tag | Description | Example |
+|-----|-------------|---------|
+| `artifact` | Maven group and artifact ID | `artifact=androidx.annotation:annotation` |
+| `artifact_versioned` | Maven coordinate with version | `artifact_versioned=androidx.annotation:annotation:1.9.1` |
+
+**Searching by artifact tag:**
+
+You can search NuGet for packages that satisfy a specific Maven dependency:
+
+```bash
+# Search for packages that bind androidx.core:core
+curl -s "https://azuresearch-usnc.nuget.org/query?q=tags:artifact=androidx.core:core&take=10" | jq '.data[] | {id: .id, version: .version}'
+```
+
+**Example: Finding the NuGet package for `androidx.annotation:annotation:1.9.1`:**
+
+1. Search NuGet for the artifact tag:
+   ```bash
+   dotnet package search "artifact=androidx.annotation:annotation" --source https://api.nuget.org/v3/index.json
+   ```
+
+2. Or visit NuGet.org and search: `tags:"artifact=androidx.annotation:annotation"`
+
+3. The result will show `Xamarin.AndroidX.Annotation` which includes:
+   - Tag: `artifact=androidx.annotation:annotation`
+   - Tag: `artifact_versioned=androidx.annotation:annotation:1.9.1`
+
+**Verifying package contents:**
+
+Once you find a candidate package, verify it advertises the correct artifact:
+
+```bash
+# Download and inspect the nuspec
+nuget install Xamarin.AndroidX.Annotation -Version 1.9.1 -OutputDirectory ./packages
+cat ./packages/Xamarin.AndroidX.Annotation.1.9.1/Xamarin.AndroidX.Annotation.nuspec | grep -A2 "<tags>"
+```
+
+#### Common Maven-to-NuGet Mappings
+
+Here's a reference for commonly needed packages:
+
+| Maven Artifact | NuGet Package | Tag Search |
+|----------------|---------------|------------|
+| `androidx.annotation:annotation` | `Xamarin.AndroidX.Annotation` | `artifact=androidx.annotation:annotation` |
+| `androidx.core:core` | `Xamarin.AndroidX.Core` | `artifact=androidx.core:core` |
+| `androidx.core:core-ktx` | `Xamarin.AndroidX.Core.Core.Ktx` | `artifact=androidx.core:core-ktx` |
+| `androidx.appcompat:appcompat` | `Xamarin.AndroidX.AppCompat` | `artifact=androidx.appcompat:appcompat` |
+| `androidx.fragment:fragment` | `Xamarin.AndroidX.Fragment` | `artifact=androidx.fragment:fragment` |
+| `androidx.activity:activity` | `Xamarin.AndroidX.Activity` | `artifact=androidx.activity:activity` |
+| `androidx.lifecycle:lifecycle-common` | `Xamarin.AndroidX.Lifecycle.Common` | `artifact=androidx.lifecycle:lifecycle-common` |
+| `org.jetbrains.kotlin:kotlin-stdlib` | `Xamarin.Kotlin.StdLib` | `artifact=org.jetbrains.kotlin:kotlin-stdlib` |
+| `org.jetbrains.kotlinx:kotlinx-coroutines-core` | `Xamarin.KotlinX.Coroutines.Core` | `artifact=org.jetbrains.kotlinx:kotlinx-coroutines-core` |
+| `com.google.android.material:material` | `Xamarin.Google.Android.Material` | `artifact=com.google.android.material:material` |
+
+#### Handling Version Mismatches
+
+When the NuGet package version doesn't exactly match the Maven version you need:
+
+1. **Check if a higher version works:** NuGet packages often bind newer versions that are backward compatible.
+
+2. **Explicitly declare the artifact version:** If the package doesn't advertise the artifact or version is mismatched:
+   ```xml
+   <PackageReference 
+     Include="Xamarin.AndroidX.Core" 
+     Version="1.12.0.3"
+     JavaArtifact="androidx.core:core"
+     JavaVersion="1.12.0" />
+   ```
+
+3. **Use `@(AndroidIgnoredJavaDependency)` for minor version differences** when you've verified compatibility:
+   ```xml
+   <AndroidIgnoredJavaDependency Include="androidx.core:core:1.13.0" />
+   ```
+
+#### When No NuGet Package Exists
+
+If you can't find a NuGet package for a dependency:
+
+1. **Check if it's a transitive-only dependency** - use `Bind="false"`:
+   ```xml
+   <AndroidMavenLibrary Include="com.example:internal-lib" Version="1.0.0" Bind="false" />
+   ```
+
+2. **Check if it's compile-time only** (annotations, processors) - ignore it:
+   ```xml
+   <AndroidIgnoredJavaDependency Include="com.google.errorprone:error_prone_annotations:2.15.0" />
+   ```
+
+3. **Create your own binding** - see the binding project creation steps below.
+
+---
+
+## Traditional Full Bindings
+
+This approach binds an entire AAR/JAR library, automatically generating C# wrappers for all public APIs.
+
+### Prerequisites
+
+- .NET 9 SDK (recommended for Java Dependency Verification)
+- JDK 17+
+- Android SDK
+- Visual Studio 2022+ or VS Code with .NET MAUI extension
+
+### Step 1: Create the Binding Project
+
+```bash
+dotnet new androidbinding -n "MyLibrary.Android.Binding"
+```
+
+Or in Visual Studio: **File → New Project → Android Java Binding Library**
+
+### Step 2: Add the Native Library
+
+Place your `.aar` or `.jar` file in the project. In .NET 9+, files are automatically detected with appropriate build actions.
+
+#### Project File Structure
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0-android</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <!-- AAR/JAR files in project folder are auto-detected -->
+  <!-- Use Update to modify auto-detected files -->
+  <ItemGroup>
+    <AndroidLibrary Update="mylibrary.aar" />
+  </ItemGroup>
+</Project>
+```
+
+### Step 3: Binding from Maven (Recommended for .NET 9+)
+
+Instead of manually downloading libraries, use `<AndroidMavenLibrary>`:
+
+```xml
+<ItemGroup>
+  <!-- Include format is {GroupId}:{ArtifactId} -->
+  <AndroidMavenLibrary Include="com.squareup.okhttp3:okhttp" Version="4.12.0" />
+</ItemGroup>
+```
+
+This automatically:
+- Downloads the AAR/JAR from Maven Central
+- Downloads the POM file for dependency verification
+- Caches the files locally
+
+#### Using Different Maven Repositories
+
+```xml
+<!-- Google's Maven Repository -->
+<AndroidMavenLibrary 
+  Include="androidx.core:core" 
+  Version="1.12.0" 
+  Repository="Google" />
+
+<!-- Custom Maven Repository -->
+<AndroidMavenLibrary 
+  Include="com.example:library" 
+  Version="1.0.0" 
+  Repository="https://maven.example.com/releases" />
+```
+
+### Step 4: Manual Library Reference
+
+For libraries not in Maven, add them manually:
+
+```xml
+<ItemGroup>
+  <!-- Bind and include the library -->
+  <AndroidLibrary Include="mylibrary.aar" />
+  
+  <!-- With POM for dependency verification (.NET 9+) -->
+  <AndroidLibrary 
+    Include="mylibrary.aar" 
+    Manifest="mylibrary.pom"
+    JavaArtifact="com.example:mylibrary"
+    JavaVersion="1.0.0" />
+</ItemGroup>
+```
+
+---
+
+## Resolving Dependencies: The Critical Step
+
+This is where most Android binding projects fail. .NET 9+ includes Java Dependency Verification that will surface errors like:
+
+```
+error XA4241: Java dependency 'androidx.core:core:1.9.0' is not satisfied.
+error XA4242: Java dependency 'org.jetbrains.kotlin:kotlin-stdlib:1.9.0' is not satisfied. 
+              Microsoft maintains the NuGet package 'Xamarin.Kotlin.StdLib' that could fulfill this dependency.
+```
+
+### Understanding XA4241 vs XA4242
+
+| Error | Meaning |
+|-------|---------|
+| **XA4241** | No known NuGet package exists for this dependency |
+| **XA4242** | Microsoft maintains a NuGet package that could satisfy this dependency |
+
+### Dependency Resolution Strategies
+
+You have four options to satisfy each dependency, and choosing the right one is crucial:
+
+#### Option 1: NuGet Packages (Preferred)
+
+Use existing NuGet bindings maintained by Microsoft or the community.
+
+```xml
+<ItemGroup>
+  <!-- AndroidX libraries -->
+  <PackageReference Include="Xamarin.AndroidX.Core" Version="1.12.0.3" />
+  <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.6" />
+  <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.3.2.2" />
+  
+  <!-- Kotlin -->
+  <PackageReference Include="Xamarin.Kotlin.StdLib" Version="1.9.22" />
+  
+  <!-- Google Play Services -->
+  <PackageReference Include="Xamarin.GooglePlayServices.Base" Version="118.2.0.3" />
+</ItemGroup>
+```
+
+**Finding the Right NuGet Package:**
+
+| Maven Artifact | NuGet Package |
+|----------------|---------------|
+| `androidx.core:core` | `Xamarin.AndroidX.Core` |
+| `androidx.appcompat:appcompat` | `Xamarin.AndroidX.AppCompat` |
+| `androidx.recyclerview:recyclerview` | `Xamarin.AndroidX.RecyclerView` |
+| `androidx.fragment:fragment` | `Xamarin.AndroidX.Fragment` |
+| `org.jetbrains.kotlin:kotlin-stdlib` | `Xamarin.Kotlin.StdLib` |
+| `com.google.android.gms:play-services-*` | `Xamarin.GooglePlayServices.*` |
+| `com.google.firebase:firebase-*` | `Xamarin.Firebase.*` |
+
+**When a NuGet Package Doesn't Advertise Its Artifact:**
+
+Some packages don't include the `artifact=` tag. Explicitly declare what they provide:
+
+```xml
+<PackageReference 
+  Include="Xamarin.Kotlin.StdLib" 
+  Version="1.9.22"
+  JavaArtifact="org.jetbrains.kotlin:kotlin-stdlib:1.9.22" />
+```
+
+#### Option 2: AndroidMavenLibrary (Without Binding)
+
+Include the Java dependency but don't create C# bindings for it:
+
+```xml
+<ItemGroup>
+  <!-- Include but don't bind -->
+  <AndroidMavenLibrary 
+    Include="com.example:dependency-lib" 
+    Version="1.0.0" 
+    Bind="false" />
+</ItemGroup>
+```
+
+**When to use this:**
+- The dependency is only used internally by your main library
+- You don't need to call the dependency's APIs from C#
+- No NuGet package exists for the dependency
+
+#### Option 3: Direct AAR/JAR Reference (Without Binding)
+
+For dependencies you have locally:
+
+```xml
+<ItemGroup>
+  <!-- Include dependency, don't bind it -->
+  <AndroidLibrary 
+    Include="dependency.aar" 
+    JavaArtifact="com.example:dependency:1.0.0"
+    Bind="false" />
+</ItemGroup>
+```
+
+#### Option 4: Ignore Dependency (Last Resort)
+
+For compile-time only dependencies (annotations, etc.):
+
+```xml
+<ItemGroup>
+  <!-- Ignore this dependency - use with caution! -->
+  <AndroidIgnoredJavaDependency 
+    Include="com.google.errorprone:error_prone_annotations:2.15.0" />
+    
+  <!-- Can ignore multiple versions -->
+  <AndroidIgnoredJavaDependency 
+    Include="org.jetbrains:annotations:13.0;org.jetbrains:annotations:23.0.0" />
+</ItemGroup>
+```
+
+**Warning:** If the dependency is actually needed at runtime, your app will crash with `Java.Lang.NoClassDefFoundError`. Only use this for:
+- Annotation processors
+- Compile-time code generators
+- Build tools
+
+### Dependency Resolution Decision Tree
+
+```
+For each unsatisfied dependency:
+│
+├─ Is there a XA4242 suggestion?
+│   └─ YES → Install the suggested NuGet package
+│
+├─ Is the dependency needed from C#?
+│   ├─ YES → Find/create a binding NuGet or create your own binding project
+│   └─ NO → Use AndroidMavenLibrary with Bind="false"
+│
+├─ Is it a compile-time only dependency (annotations)?
+│   └─ YES → Use AndroidIgnoredJavaDependency
+│
+└─ Otherwise → Create a separate binding project or include AAR/JAR directly
+```
+
+### Practical Example: Binding a Complex Library
+
+Let's say you want to bind a library that depends on OkHttp, Kotlin, and AndroidX:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0-android</TargetFramework>
+  </PropertyGroup>
+
+  <!-- The library to bind -->
+  <ItemGroup>
+    <AndroidMavenLibrary Include="com.example:complexlib" Version="2.0.0" />
+  </ItemGroup>
+
+  <!-- Dependencies satisfied by NuGet (preferred) -->
+  <ItemGroup>
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.12.0.3" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.6" />
+    <PackageReference Include="Xamarin.Kotlin.StdLib" Version="1.9.22" />
+    <PackageReference Include="Square.OkHttp3" Version="4.12.0" />
+  </ItemGroup>
+
+  <!-- Dependencies with no NuGet - include but don't bind -->
+  <ItemGroup>
+    <AndroidMavenLibrary 
+      Include="com.example:internal-util" 
+      Version="1.0.0" 
+      Bind="false" />
+  </ItemGroup>
+
+  <!-- Compile-time only dependencies -->
+  <ItemGroup>
+    <AndroidIgnoredJavaDependency 
+      Include="org.jetbrains:annotations:23.0.0" />
+  </ItemGroup>
+</Project>
+```
+
+---
+
+## Customizing Bindings with Metadata
+
+Even after resolving dependencies, the generated C# code often needs adjustments. This is done via `Transforms/Metadata.xml`.
+
+### How Binding Generation Works
+
+1. **Parse Phase**: The binding generator reads the JAR/AAR and produces `obj/Debug/api.xml`
+2. **Transform Phase**: `Metadata.xml` transforms modify the API definition
+3. **Generate Phase**: C# code is generated from the transformed API
+
+### Common Metadata Transforms
+
+#### Removing Obfuscated or Internal Types
+
+```xml
+<metadata>
+  <!-- Remove obfuscated packages (single letters, $, etc.) -->
+  <remove-node path="/api/package[starts-with(@name, 'com.example.internal')]" />
+  <remove-node path="/api/package[@name='a']" />
+  <remove-node path="/api/package[@name='b']" />
+  
+  <!-- Remove specific classes -->
+  <remove-node path="/api/package[@name='com.example']/class[@name='InternalHelper']" />
+  
+  <!-- Remove classes with $ (often internal/anonymous) -->
+  <remove-node path="/api/package/class[contains(@name, '$')]" />
+</metadata>
+```
+
+#### Changing Namespaces
+
+```xml
+<metadata>
+  <!-- Change Java package to .NET namespace -->
+  <attr 
+    path="/api/package[@name='com.example.library']" 
+    name="managedName">Example.Library</attr>
+    
+  <!-- Multiple packages -->
+  <attr path="/api/package[@name='com.example.library.ui']" 
+    name="managedName">Example.Library.UI</attr>
+</metadata>
+```
+
+#### Renaming Types and Members
+
+```xml
+<metadata>
+  <!-- Rename a class -->
+  <attr 
+    path="/api/package[@name='com.example']/class[@name='Util']" 
+    name="managedName">Utilities</attr>
+    
+  <!-- Rename a method -->
+  <attr 
+    path="/api/package[@name='com.example']/class[@name='MyClass']/method[@name='getData']" 
+    name="managedName">GetData</attr>
+    
+  <!-- Rename parameters (p0, p1 → meaningful names) -->
+  <attr 
+    path="/api/package[@name='com.example']/class[@name='MyClass']/method[@name='process']/parameter[@name='p0']" 
+    name="name">input</attr>
+</metadata>
+```
+
+#### Fixing Visibility Issues
+
+```xml
+<metadata>
+  <!-- Make a class public -->
+  <attr 
+    path="/api/package[@name='com.example']/class[@name='Helper']" 
+    name="visibility">public</attr>
+</metadata>
+```
+
+#### Handling Obfuscated Code
+
+```xml
+<metadata>
+  <!-- Mark obfuscated classes to still generate bindings -->
+  <attr 
+    path="/api/package[@name='com.example']/class[@name='a']" 
+    name="obfuscated">false</attr>
+</metadata>
+```
+
+#### Fixing Return Types
+
+```xml
+<metadata>
+  <!-- Change method return type -->
+  <attr 
+    path="/api/package[@name='com.example']/class[@name='MyClass']/method[@name='getObject']" 
+    name="managedReturn">Java.Lang.Object</attr>
+</metadata>
+```
+
+### The api.xml Reference
+
+When troubleshooting, examine `obj/Debug/net9.0-android/api.xml` to see what's being generated. This helps construct the correct XPath for your transforms.
+
+---
+
+## Native Library Interop (Slim Bindings) for Android
+
+This approach creates a thin Java/Kotlin wrapper, exposing only the APIs you need.
+
+### Project Structure
+
+```
+MyBinding/
+├── android/
+│   ├── native/                          # Android Studio project
+│   │   ├── app/
+│   │   │   └── src/main/java/
+│   │   │       └── com/example/
+│   │   │           └── DotnetMyBinding.java
+│   │   ├── build.gradle.kts
+│   │   └── settings.gradle.kts
+│   └── MyBinding.Android.Binding/       # .NET binding project
+│       ├── MyBinding.Android.Binding.csproj
+│       └── Transforms/
+│           └── Metadata.xml
+└── sample/
+    └── MauiSample/
+```
+
+### Step 1: Create the Android Studio Wrapper Project
+
+Create a new Android Library module in Android Studio.
+
+#### build.gradle.kts (Module)
+
+```kotlin
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.mybinding"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 21
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+        }
+    }
+}
+
+dependencies {
+    // The native library you're wrapping
+    implementation("com.thirdparty:awesomelib:1.0.0")
+    
+    // Any other dependencies
+    implementation("androidx.core:core-ktx:1.12.0")
+}
+```
+
+#### settings.gradle.kts
+
+```kotlin
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        // Add custom repositories if needed
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+```
+
+### Step 2: Create the Wrapper Class
+
+**Java Example:** `DotnetMyBinding.java`
+
+```java
+package com.example.mybinding;
+
+import android.content.Context;
+import android.util.Log;
+import com.thirdparty.awesomelib.AwesomeLib;
+import com.thirdparty.awesomelib.AwesomeCallback;
+
+public class DotnetMyBinding {
+    private static final String TAG = "DotnetMyBinding";
+    private static AwesomeLib instance;
+
+    // Initialize the library
+    public static void initialize(Context context, boolean debug) {
+        AwesomeLib.Builder builder = new AwesomeLib.Builder(context);
+        if (debug) {
+            builder.setLoggingEnabled(true);
+        }
+        instance = builder.build();
+    }
+
+    // Simple method wrapper
+    public static String getData() {
+        if (instance == null) {
+            throw new IllegalStateException("Must call initialize() first");
+        }
+        return instance.getData();
+    }
+
+    // Callback-based method
+    public static void fetchDataAsync(final DataCallback callback) {
+        if (instance == null) {
+            callback.onError("Not initialized");
+            return;
+        }
+        
+        instance.fetchData(new AwesomeCallback() {
+            @Override
+            public void onSuccess(String result) {
+                callback.onSuccess(result);
+            }
+
+            @Override
+            public void onError(Exception e) {
+                callback.onError(e.getMessage());
+            }
+        });
+    }
+
+    // Callback interface for .NET
+    public interface DataCallback {
+        void onSuccess(String result);
+        void onError(String error);
+    }
+}
+```
+
+**Kotlin Example:** `DotnetMyBinding.kt`
+
+```kotlin
+package com.example.mybinding
+
+import android.content.Context
+import com.thirdparty.awesomelib.AwesomeLib
+
+object DotnetMyBinding {
+    private var instance: AwesomeLib? = null
+
+    @JvmStatic
+    fun initialize(context: Context, debug: Boolean) {
+        instance = AwesomeLib.Builder(context)
+            .setLoggingEnabled(debug)
+            .build()
+    }
+
+    @JvmStatic
+    fun getData(): String {
+        return instance?.getData() 
+            ?: throw IllegalStateException("Must call initialize() first")
+    }
+
+    @JvmStatic
+    fun fetchDataAsync(callback: DataCallback) {
+        instance?.fetchData { result, error ->
+            if (error != null) {
+                callback.onError(error.message ?: "Unknown error")
+            } else {
+                callback.onSuccess(result ?: "")
+            }
+        } ?: callback.onError("Not initialized")
+    }
+
+    interface DataCallback {
+        fun onSuccess(result: String)
+        fun onError(error: String)
+    }
+}
+```
+
+**Key Points:**
+- Use `@JvmStatic` in Kotlin for static methods
+- Keep method signatures simple (primitives, String, common Android types)
+- Use callback interfaces instead of coroutines/lambdas for async operations
+
+### Step 3: Build the AAR
+
+```bash
+cd android/native
+./gradlew :app:assembleRelease
+```
+
+The AAR will be at `app/build/outputs/aar/app-release.aar`.
+
+### Step 4: Configure the Binding Project
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0-android</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+  </PropertyGroup>
+
+  <!-- Your wrapper AAR -->
+  <ItemGroup>
+    <AndroidLibrary Include="../native/app/build/outputs/aar/app-release.aar" />
+  </ItemGroup>
+
+  <!-- Dependencies required by your wrapper -->
+  <ItemGroup Condition="$(TargetFramework.Contains('android'))">
+    <!-- The library you're wrapping - don't bind, just include -->
+    <AndroidMavenLibrary 
+      Include="com.thirdparty:awesomelib" 
+      Version="1.0.0" 
+      Bind="false" />
+      
+    <!-- NuGet packages for common dependencies -->
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.12.0.3" />
+    <PackageReference Include="Xamarin.Kotlin.StdLib" Version="1.9.22" />
+  </ItemGroup>
+
+  <!-- Metadata transforms -->
+  <ItemGroup>
+    <TransformFile Include="Transforms\Metadata.xml" />
+  </ItemGroup>
+</Project>
+```
+
+### Step 5: Optional Metadata Customization
+
+`Transforms/Metadata.xml`:
+
+```xml
+<metadata>
+  <!-- Rename the namespace -->
+  <attr 
+    path="/api/package[@name='com.example.mybinding']" 
+    name="managedName">MyBinding</attr>
+</metadata>
+```
+
+### Step 6: Reference in Your App
+
+Add to your MAUI app's `.csproj`:
+
+```xml
+<ItemGroup Condition="$(TargetFramework.Contains('android'))">
+  <ProjectReference Include="..\android\MyBinding.Android.Binding\MyBinding.Android.Binding.csproj" />
+</ItemGroup>
+```
+
+### Step 7: Use in C#
+
+```csharp
+#if ANDROID
+using MyBinding;
+using Android.Runtime;
+#endif
+
+public partial class MainPage : ContentPage
+{
+    public MainPage()
+    {
+        InitializeComponent();
+        
+#if ANDROID
+        var context = Platform.CurrentActivity ?? Platform.AppContext;
+        Com.Example.Mybinding.DotnetMyBinding.Initialize(context, true);
+#endif
+    }
+
+    private void OnButtonClicked(object sender, EventArgs e)
+    {
+#if ANDROID
+        // Sync method
+        var data = Com.Example.Mybinding.DotnetMyBinding.GetData();
+        
+        // Async with callback
+        Com.Example.Mybinding.DotnetMyBinding.FetchDataAsync(new MyDataCallback(
+            onSuccess: result => MainThread.BeginInvokeOnMainThread(() => 
+                DisplayAlert("Success", result, "OK")),
+            onError: error => MainThread.BeginInvokeOnMainThread(() => 
+                DisplayAlert("Error", error, "OK"))
+        ));
+#endif
+    }
+}
+
+#if ANDROID
+// Implement the callback interface
+public class MyDataCallback : Java.Lang.Object, Com.Example.Mybinding.DotnetMyBinding.IDataCallback
+{
+    private readonly Action<string> _onSuccess;
+    private readonly Action<string> _onError;
+
+    public MyDataCallback(Action<string> onSuccess, Action<string> onError)
+    {
+        _onSuccess = onSuccess;
+        _onError = onError;
+    }
+
+    public void OnSuccess(string result) => _onSuccess(result);
+    public void OnError(string error) => _onError(error);
+}
+#endif
+```
+
+---
+
+## Handling Native Libraries (.so files)
+
+Some Android libraries include native code (`.so` files). If you get `java.lang.UnsatisfiedLinkError`, you need to ensure the native libraries are loaded.
+
+### Including .so Files
+
+For AAR files, `.so` files are usually included automatically. For JAR files, you may need to add them manually:
+
+```xml
+<ItemGroup>
+  <AndroidNativeLibrary Include="libs\arm64-v8a\libmynative.so">
+    <Abi>arm64-v8a</Abi>
+  </AndroidNativeLibrary>
+  <AndroidNativeLibrary Include="libs\armeabi-v7a\libmynative.so">
+    <Abi>armeabi-v7a</Abi>
+  </AndroidNativeLibrary>
+  <AndroidNativeLibrary Include="libs\x86_64\libmynative.so">
+    <Abi>x86_64</Abi>
+  </AndroidNativeLibrary>
+</ItemGroup>
+```
+
+### Manually Loading Native Libraries
+
+Sometimes you need to explicitly load the native library:
+
+```csharp
+// In your Android initialization code
+Java.Lang.JavaSystem.LoadLibrary("mynative");
+```
+
+---
+
+## Troubleshooting Common Issues
+
+### Build Errors
+
+#### "Type is defined multiple times"
+You have duplicate classes, often from including the same dependency twice (once via NuGet, once via AAR).
+
+**Solution:** Check your dependencies for overlap. Use `Bind="false"` or remove redundant references.
+
+```xml
+<!-- If kotlin-stdlib is in both NuGet and your AAR -->
+<AndroidLibrary Update="mylibrary.aar">
+  <!-- Exclude the embedded kotlin from AAR -->
+</AndroidLibrary>
+```
+
+#### "Java dependency 'X' is not satisfied"
+Missing transitive dependency.
+
+**Solution:** Add the dependency via NuGet, AndroidMavenLibrary, or AndroidIgnoredJavaDependency.
+
+#### "Class 'X' does not implement interface member 'Y'"
+Covariant return types or interface implementation issues.
+
+**Solution:** Add custom implementation in `Additions/` folder:
+
+```csharp
+// Additions/MyClassAdditions.cs
+namespace Com.Example
+{
+    public partial class MyClass
+    {
+        Java.Lang.Object SomeInterface.SomeMethod()
+        {
+            return RawSomeMethod();
+        }
+    }
+}
+```
+
+### Runtime Errors
+
+#### `Java.Lang.NoClassDefFoundError`
+Missing dependency at runtime.
+
+**Solution:** You ignored a required dependency. Remove it from `AndroidIgnoredJavaDependency` and properly satisfy it.
+
+#### `Java.Lang.UnsatisfiedLinkError`
+Native library (.so) not loaded.
+
+**Solution:** Ensure .so files are included and call `JavaSystem.LoadLibrary()` if needed.
+
+---
+
+## Best Practices
+
+### Dependency Management
+
+1. **Prefer NuGet packages** - They handle transitive dependencies automatically
+2. **Use Java Dependency Verification** - Upgrade to .NET 9+ for error XA4241/XA4242
+3. **Don't bind what you don't need** - Use `Bind="false"` liberally
+4. **Version alignment** - Match NuGet package versions with what your library expects
+
+### Project Organization
+
+1. **Separate binding projects** - One per major library
+2. **Document dependencies** - Comment why each dependency is included
+3. **Test on real devices** - Emulators may hide some linking issues
+
+### For Slim Bindings
+
+1. **Keep wrapper APIs simple** - Primitives, strings, common types
+2. **Use callback interfaces** - Not lambdas or coroutines
+3. **Test the native project first** - Ensure it works in pure Android before binding
+
+---
+
+## Quick Reference
+
+### Build Items
+
+| Item | Purpose |
+|------|---------|
+| `<AndroidLibrary>` | Include AAR/JAR in binding |
+| `<AndroidMavenLibrary>` | Download and include from Maven |
+| `<AndroidIgnoredJavaDependency>` | Ignore a dependency (compile-time only) |
+| `<AndroidNativeLibrary>` | Include .so files |
+| `<TransformFile>` | Metadata transform files |
+
+### Common Attributes
+
+| Attribute | Values | Purpose |
+|-----------|--------|---------|
+| `Bind` | `true`/`false` | Whether to generate C# bindings |
+| `Pack` | `true`/`false` | Whether to include in NuGet package |
+| `JavaArtifact` | `groupId:artifactId:version` | Declare what Maven artifact this satisfies |
+| `Repository` | `Central`/`Google`/URL | Maven repository to download from |
+| `VerifyDependencies` | `true`/`false` | Enable Java Dependency Verification |
+
+### Common NuGet Packages
+
+| Maven Artifact | NuGet Package |
+|----------------|---------------|
+| `androidx.core:core` | `Xamarin.AndroidX.Core` |
+| `androidx.appcompat:appcompat` | `Xamarin.AndroidX.AppCompat` |
+| `androidx.recyclerview:recyclerview` | `Xamarin.AndroidX.RecyclerView` |
+| `androidx.fragment:fragment` | `Xamarin.AndroidX.Fragment` |
+| `androidx.activity:activity` | `Xamarin.AndroidX.Activity` |
+| `androidx.lifecycle:lifecycle-*` | `Xamarin.AndroidX.Lifecycle.*` |
+| `org.jetbrains.kotlin:kotlin-stdlib` | `Xamarin.Kotlin.StdLib` |
+| `org.jetbrains.kotlinx:kotlinx-coroutines-*` | `Xamarin.KotlinX.Coroutines.*` |
+| `com.google.android.gms:play-services-base` | `Xamarin.GooglePlayServices.Base` |
+| `com.google.android.material:material` | `Xamarin.Google.Android.Material` |
+| `com.squareup.okhttp3:okhttp` | `Square.OkHttp3` |
+| `com.google.code.gson:gson` | `GoogleGson` |
+
+---
+
+## Resources
+
+- [Binding a Java Library (Microsoft Docs)](https://learn.microsoft.com/dotnet/android/binding-libs/binding-java-libs/binding-java-library)
+- [Binding from Maven (Microsoft Docs)](https://learn.microsoft.com/dotnet/android/binding-libs/binding-java-libs/binding-java-maven-library)
+- [Java Dependency Verification](https://learn.microsoft.com/dotnet/android/binding-libs/advanced-concepts/java-dependency-verification)
+- [Resolving Java Dependencies](https://learn.microsoft.com/dotnet/android/binding-libs/advanced-concepts/resolving-java-dependencies)
+- [Java Bindings Metadata](https://learn.microsoft.com/dotnet/android/binding-libs/customizing-bindings/java-bindings-metadata)
+- [Maui.NativeLibraryInterop Repository](https://github.com/CommunityToolkit/Maui.NativeLibraryInterop)
+- [Xamarin.AndroidX Repository](https://github.com/xamarin/AndroidX)

--- a/.claude/skills/android-slim-bindings/references/android-slim-bindings-implementation.md
+++ b/.claude/skills/android-slim-bindings/references/android-slim-bindings-implementation.md
@@ -1,0 +1,1046 @@
+# Android Slim Bindings — Detailed Implementation Guide
+
+This reference contains detailed code examples, step-by-step instructions, troubleshooting, and complete scripts for creating Android slim bindings. For the high-level workflow overview, see the main [SKILL.md](../SKILL.md).
+
+---
+
+## Step 1: Prerequisites
+
+Ensure you have:
+- JDK 17+
+- Android SDK with `ANDROID_HOME` environment variable set
+- .NET SDK 9+ (recommended for Java Dependency Verification)
+
+> **Note:** You don't need Gradle installed globally—we'll use the Gradle Wrapper which downloads the correct version automatically.
+
+## Step 2: Create the Android Library Project
+
+### Option A: Use Android Studio (Recommended for GUI)
+
+1. **Open Android Studio**
+2. **File → New → New Project**
+3. Select **"No Activity"** template
+4. Configure:
+   - Name: `MyBindingNative`
+   - Package name: `com.example.mybinding`
+   - Language: Java or Kotlin
+   - Minimum SDK: API 21
+5. **File → New → New Module**
+6. Select **"Android Library"**
+7. Name it `app` (or your preferred module name)
+
+### Option B: Use `gradle init` with Wrapper (CLI)
+
+```bash
+# Set your binding name
+BINDING_NAME="MyBinding"
+PACKAGE_NAME="com.example.mybinding"
+
+# Create directory structure
+mkdir -p ${BINDING_NAME}/android/native
+mkdir -p ${BINDING_NAME}/android/${BINDING_NAME}.Android.Binding/Transforms
+mkdir -p ${BINDING_NAME}/sample/MauiSample
+
+cd ${BINDING_NAME}/android/native
+
+# Download and use Gradle wrapper (no global Gradle install needed)
+curl -sL https://services.gradle.org/distributions/gradle-9.2.1-bin.zip -o gradle.zip
+unzip -q gradle.zip
+./gradle-9.2.1/bin/gradle wrapper --gradle-version 9.2.1
+rm -rf gradle.zip gradle-9.2.1
+
+# Initialize a basic Kotlin library project
+./gradlew init --type kotlin-library --dsl kotlin --project-name ${BINDING_NAME}Native --package ${PACKAGE_NAME} --no-split-project --java-version 17
+
+# The project needs to be converted to Android Library (see next section)
+```
+
+> **Note:** `gradle init` creates a standard JVM library, not an Android library. You'll need to modify the generated files to add Android support (see "Converting to Android Library" below).
+
+### Option C: Clone from Template Repository
+
+```bash
+BINDING_NAME="MyBinding"
+
+# Clone the template
+git clone https://github.com/AdrianSimionescu/NativeLibraryInterop-Template.git ${BINDING_NAME}
+cd ${BINDING_NAME}
+
+# Or use the official CommunityToolkit repo structure
+git clone --depth 1 https://github.com/AdrianSimionescu/NativeLibraryInterop-Template.git ${BINDING_NAME}
+
+# Rename files and references
+find . -type f -name "*.gradle*" -exec sed -i '' 's/TemplateBinding/'"${BINDING_NAME}"'/g' {} \;
+```
+
+### Option D: Manual Creation with Gradle Wrapper
+
+```bash
+BINDING_NAME="MyBinding"
+PACKAGE_NAME="com.example.mybinding"
+PACKAGE_PATH="${PACKAGE_NAME//./\/}"
+
+# Create directory structure
+mkdir -p ${BINDING_NAME}/android/native/app/src/main/java/${PACKAGE_PATH}
+mkdir -p ${BINDING_NAME}/android/${BINDING_NAME}.Android.Binding/Transforms
+mkdir -p ${BINDING_NAME}/sample/MauiSample
+
+cd ${BINDING_NAME}/android/native
+
+# Create Gradle wrapper
+mkdir -p tmp && cd tmp
+curl -sL https://services.gradle.org/distributions/gradle-9.2.1-bin.zip -o gradle.zip
+unzip -q gradle.zip && ./gradle-9.2.1/bin/gradle wrapper --gradle-version 9.2.1
+mv gradlew gradlew.bat gradle ../ && cd .. && rm -rf tmp
+```
+
+### Creating Gradle Build Files
+
+**settings.gradle.kts:**
+
+```kotlin
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "MyBindingNative"
+include(":app")
+```
+
+**build.gradle.kts (root):**
+
+```kotlin
+plugins {
+    id("com.android.library") version "8.2.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+}
+```
+
+**app/build.gradle.kts:**
+
+```kotlin
+plugins {
+    id("com.android.library")
+}
+
+android {
+    namespace = "com.example.mybinding"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 21
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    // Add the native library you want to wrap
+    // implementation("com.squareup.okhttp3:okhttp:4.12.0")
+}
+```
+
+### Checking for Latest Versions
+
+```bash
+# Check latest Android Gradle Plugin version
+open "https://developer.android.com/build/releases/gradle-plugin"
+
+# Check latest Kotlin version
+curl -s "https://api.github.com/repos/JetBrains/kotlin/releases/latest" | grep '"tag_name"' | cut -d'"' -f4
+```
+
+## Step 3: Analyze the Full Dependency Tree
+
+```bash
+# Get full dependency tree
+./gradlew app:dependencies --configuration releaseRuntimeClasspath
+
+# Get flat list of all dependencies
+./gradlew app:dependencies --configuration releaseRuntimeClasspath | grep -E "^[+\\\\]" | sed 's/.*--- //' | sort -u
+
+# For insight into a specific dependency
+./gradlew app:dependencyInsight --dependency kotlin-stdlib --configuration releaseRuntimeClasspath
+```
+
+**Understanding the output:**
+- `->` indicates version conflict resolution (e.g., `1.9.10 -> 1.9.21`)
+- `(*)` indicates the dependency was already shown elsewhere (deduplication)
+- `(c)` indicates a constraint
+
+### Document Your Dependencies
+
+| Maven Artifact | Version | NuGet Package | Strategy |
+|----------------|---------|---------------|----------|
+| `androidx.core:core` | 1.12.0 | `Xamarin.AndroidX.Core` | NuGet |
+| `org.jetbrains.kotlin:kotlin-stdlib` | 1.9.22 | `Xamarin.Kotlin.StdLib` | NuGet |
+| `com.example:internal-lib` | 1.0.0 | N/A | `Bind="false"` |
+| `org.jetbrains:annotations` | 23.0.0 | N/A | Ignore |
+
+## Step 4: Create the Wrapper Class
+
+### Java Wrapper
+
+Create `app/src/main/java/com/example/mybinding/DotnetMyBinding.java`:
+
+```java
+package com.example.mybinding;
+
+import android.content.Context;
+import android.util.Log;
+import android.view.View;
+
+public class DotnetMyBinding {
+    private static final String TAG = "DotnetMyBinding";
+    private static boolean initialized = false;
+
+    // Initialization
+    public static void initialize(Context context, boolean debug) {
+        if (initialized) {
+            Log.w(TAG, "Already initialized");
+            return;
+        }
+        // Initialize your native library here
+        initialized = true;
+        Log.d(TAG, "MyBinding initialized");
+    }
+
+    public static boolean isInitialized() {
+        return initialized;
+    }
+
+    // Synchronous Methods
+    public static String getVersion() {
+        return "1.0.0";
+    }
+
+    public static String processData(String input) {
+        if (!initialized) {
+            throw new IllegalStateException("Must call initialize() first");
+        }
+        return "Processed: " + input;
+    }
+
+    // Asynchronous Methods (Callback Pattern)
+    public interface DataCallback {
+        void onSuccess(String result);
+        void onError(String error);
+    }
+
+    public static void fetchDataAsync(String query, final DataCallback callback) {
+        if (!initialized) {
+            callback.onError("Not initialized");
+            return;
+        }
+        new Thread(() -> {
+            try {
+                Thread.sleep(100);
+                String result = "Result for: " + query;
+                callback.onSuccess(result);
+            } catch (Exception e) {
+                callback.onError(e.getMessage());
+            }
+        }).start();
+    }
+
+    // Complex callback with multiple result types
+    public interface ComplexCallback {
+        void onSuccess(String data, int count, boolean hasMore);
+        void onError(int errorCode, String errorMessage);
+    }
+
+    public static void performComplexOperation(
+            String input, int options, final ComplexCallback callback) {
+        callback.onSuccess("data", 42, true);
+    }
+
+    // View Creation
+    public static View createView(Context context) {
+        View view = new View(context);
+        view.setBackgroundColor(0xFF0066CC);
+        return view;
+    }
+
+    // Event Handling
+    public interface EventListener {
+        void onEvent(String eventType, String eventData);
+    }
+
+    private static EventListener eventListener;
+
+    public static void setEventListener(EventListener listener) {
+        eventListener = listener;
+    }
+
+    public static void removeEventListener() {
+        eventListener = null;
+    }
+
+    // Configuration
+    public static void configure(
+            String apiKey, String apiSecret, int timeout, boolean enableLogging) {
+        Log.d(TAG, "Configured with apiKey: " + apiKey);
+    }
+}
+```
+
+### Kotlin Wrapper (Alternative)
+
+Create `app/src/main/kotlin/com/example/mybinding/DotnetMyBinding.kt`:
+
+```kotlin
+package com.example.mybinding
+
+import android.content.Context
+import android.util.Log
+import android.view.View
+
+object DotnetMyBinding {
+    private const val TAG = "DotnetMyBinding"
+    private var initialized = false
+
+    @JvmStatic
+    fun initialize(context: Context, debug: Boolean) {
+        if (initialized) { Log.w(TAG, "Already initialized"); return }
+        initialized = true
+        Log.d(TAG, "MyBinding initialized")
+    }
+
+    @JvmStatic fun isInitialized(): Boolean = initialized
+    @JvmStatic fun getVersion(): String = "1.0.0"
+
+    @JvmStatic
+    fun processData(input: String): String {
+        check(initialized) { "Must call initialize() first" }
+        return "Processed: $input"
+    }
+
+    interface DataCallback {
+        fun onSuccess(result: String)
+        fun onError(error: String)
+    }
+
+    @JvmStatic
+    fun fetchDataAsync(query: String, callback: DataCallback) {
+        if (!initialized) { callback.onError("Not initialized"); return }
+        Thread {
+            try {
+                Thread.sleep(100)
+                callback.onSuccess("Result for: $query")
+            } catch (e: Exception) {
+                callback.onError(e.message ?: "Unknown error")
+            }
+        }.start()
+    }
+
+    @JvmStatic
+    fun createView(context: Context): View {
+        return View(context).apply { setBackgroundColor(0xFF0066CC.toInt()) }
+    }
+
+    interface EventListener {
+        fun onEvent(eventType: String, eventData: String)
+    }
+
+    private var eventListener: EventListener? = null
+
+    @JvmStatic fun setEventListener(listener: EventListener?) { eventListener = listener }
+    @JvmStatic fun removeEventListener() { eventListener = null }
+
+    @JvmStatic
+    fun configure(apiKey: String, apiSecret: String, timeout: Int, enableLogging: Boolean) {
+        Log.d(TAG, "Configured with apiKey: $apiKey")
+    }
+}
+```
+
+**Key Points for Kotlin:**
+- Use `@JvmStatic` on all methods for static access from C#
+- Use `object` for singleton pattern (maps to static methods)
+- Use Java-style callback interfaces (not Kotlin lambdas)
+- Avoid coroutines in the public API (use callbacks instead)
+
+## Step 5: Build the AAR
+
+```bash
+cd android/native
+./gradlew :app:assembleRelease
+# Output: app/build/outputs/aar/app-release.aar
+```
+
+Verify contents:
+```bash
+unzip -l app/build/outputs/aar/app-release.aar
+```
+
+## Step 6: Create the C# Binding Project
+
+```bash
+cd android
+dotnet new androidbinding -n MyBinding.Android.Binding
+cd MyBinding.Android.Binding
+```
+
+### Full .csproj Example
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0-android</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
+  <!-- Your wrapper AAR -->
+  <ItemGroup>
+    <AndroidLibrary Include="../native/app/build/outputs/aar/app-release.aar" />
+  </ItemGroup>
+
+  <!-- Dependencies: NuGet packages for common libraries -->
+  <ItemGroup>
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.12.0.4" />
+    <PackageReference Include="Xamarin.Kotlin.StdLib" Version="1.9.22.1" />
+  </ItemGroup>
+
+  <!-- Dependencies without NuGet: Include but don't bind -->
+  <ItemGroup>
+    <!-- <AndroidMavenLibrary Include="com.thirdparty:awesomelib" Version="1.0.0" Bind="false" /> -->
+  </ItemGroup>
+
+  <!-- Compile-time only dependencies to ignore -->
+  <ItemGroup>
+    <AndroidIgnoredJavaDependency Include="org.jetbrains:annotations" Version="*" />
+  </ItemGroup>
+</Project>
+```
+
+### Metadata.xml
+
+```xml
+<metadata>
+  <attr path="/api/package[@name='com.example.mybinding']" 
+        name="managedName">MyBinding</attr>
+  
+  <attr path="/api/package[@name='com.example.mybinding']/class[@name='DotnetMyBinding']/method[@name='initialize']/parameter[@name='p0']" 
+        name="name">context</attr>
+  <attr path="/api/package[@name='com.example.mybinding']/class[@name='DotnetMyBinding']/method[@name='initialize']/parameter[@name='p1']" 
+        name="name">debug</attr>
+  <attr path="/api/package[@name='com.example.mybinding']/class[@name='DotnetMyBinding']/method[@name='processData']/parameter[@name='p0']" 
+        name="name">input</attr>
+  <attr path="/api/package[@name='com.example.mybinding']/class[@name='DotnetMyBinding']/method[@name='fetchDataAsync']/parameter[@name='p0']" 
+        name="name">query</attr>
+  <attr path="/api/package[@name='com.example.mybinding']/class[@name='DotnetMyBinding']/method[@name='fetchDataAsync']/parameter[@name='p1']" 
+        name="name">callback</attr>
+</metadata>
+```
+
+## Step 7: Resolve Dependencies — Detailed Examples
+
+### Finding NuGet Packages for Maven Dependencies
+
+```bash
+# Search NuGet for a specific Maven artifact
+dotnet package search "artifact=androidx.core:core" --source https://api.nuget.org/v3/index.json
+
+# Or use curl
+curl -s "https://azuresearch-usnc.nuget.org/query?q=tags:artifact=androidx.core:core&take=10" | jq '.data[] | {id: .id, version: .version}'
+```
+
+### Practical Example: Complex Library Binding
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0-android</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AndroidLibrary Include="../native/app/build/outputs/aar/app-release.aar" />
+  </ItemGroup>
+
+  <!-- Dependencies satisfied by NuGet (preferred) -->
+  <ItemGroup>
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.12.0.4" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.6" />
+    <PackageReference Include="Xamarin.Kotlin.StdLib" Version="1.9.22.1" />
+    <PackageReference Include="Square.OkHttp3" Version="4.12.0.1" />
+  </ItemGroup>
+
+  <!-- The library being wrapped - include but don't bind -->
+  <ItemGroup>
+    <AndroidMavenLibrary Include="com.thirdparty:awesomelib" Version="1.0.0" Bind="false" />
+  </ItemGroup>
+
+  <!-- Dependencies with no NuGet - include but don't bind -->
+  <ItemGroup>
+    <AndroidMavenLibrary Include="com.thirdparty:internal-util" Version="1.0.0" Bind="false" />
+  </ItemGroup>
+
+  <!-- Compile-time only dependencies to ignore -->
+  <ItemGroup>
+    <AndroidIgnoredJavaDependency Include="org.jetbrains:annotations" Version="*" />
+    <AndroidIgnoredJavaDependency Include="com.google.errorprone:error_prone_annotations" Version="*" />
+    <AndroidIgnoredJavaDependency Include="com.google.code.findbugs:jsr305" Version="*" />
+  </ItemGroup>
+</Project>
+```
+
+## Step 8: Customize Bindings with Metadata — Full Examples
+
+### Rename Java Packages to .NET Namespaces
+
+```xml
+<metadata>
+  <attr path="/api/package[@name='com.example.mybinding']" 
+        name="managedName">MyBinding</attr>
+  <attr path="/api/package[@name='com.example.mybinding.utils']" 
+        name="managedName">MyBinding.Utils</attr>
+</metadata>
+```
+
+### Rename Classes and Methods
+
+```xml
+<metadata>
+  <attr path="/api/package[@name='com.example']/class[@name='Util']" 
+        name="managedName">Utilities</attr>
+  <attr path="/api/package[@name='com.example']/class[@name='MyClass']/method[@name='getData']" 
+        name="managedName">GetData</attr>
+</metadata>
+```
+
+### Rename Parameters
+
+```xml
+<metadata>
+  <attr path="/api/package[@name='com.example']/class[@name='MyClass']/method[@name='process']/parameter[@name='p0']" 
+        name="name">input</attr>
+  <attr path="/api/package[@name='com.example']/class[@name='MyClass']/method[@name='process']/parameter[@name='p1']" 
+        name="name">options</attr>
+</metadata>
+```
+
+### Remove Internal or Obfuscated Types
+
+```xml
+<metadata>
+  <remove-node path="/api/package[starts-with(@name, 'com.example.internal')]" />
+  <remove-node path="/api/package[@name='a']" />
+  <remove-node path="/api/package[@name='b']" />
+  <remove-node path="/api/package[@name='com.example']/class[@name='InternalHelper']" />
+  <remove-node path="/api/package/class[contains(@name, '$')]" />
+</metadata>
+```
+
+### Fix Visibility Issues
+
+```xml
+<metadata>
+  <attr path="/api/package[@name='com.example']/class[@name='Helper']" 
+        name="visibility">public</attr>
+</metadata>
+```
+
+### Examining api.xml for XPath Construction
+
+```bash
+cat obj/Debug/net9.0-android/api.xml
+```
+
+## Step 10: Use in Your MAUI App — Full Examples
+
+### Add Project Reference
+
+```xml
+<ItemGroup Condition="$(TargetFramework.Contains('android'))">
+  <ProjectReference Include="..\android\MyBinding.Android.Binding\MyBinding.Android.Binding.csproj" />
+</ItemGroup>
+```
+
+### Initialize in MauiProgram.cs
+
+```csharp
+using Microsoft.Maui.Hosting;
+
+#if ANDROID
+using MyBinding;
+#endif
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder.UseMauiApp<App>();
+
+#if ANDROID
+        builder.ConfigureLifecycleEvents(lifecycle =>
+        {
+            lifecycle.AddAndroid(android =>
+            {
+                android.OnCreate((activity, bundle) =>
+                {
+                    DotnetMyBinding.Initialize(activity, debug: true);
+                });
+            });
+        });
+#endif
+
+        return builder.Build();
+    }
+}
+```
+
+### Implement Callback Interface
+
+```csharp
+#if ANDROID
+using MyBinding;
+using Android.Runtime;
+
+public class MyDataCallback : Java.Lang.Object, DotnetMyBinding.IDataCallback
+{
+    private readonly Action<string> _onSuccess;
+    private readonly Action<string> _onError;
+
+    public MyDataCallback(Action<string> onSuccess, Action<string> onError)
+    {
+        _onSuccess = onSuccess;
+        _onError = onError;
+    }
+
+    public void OnSuccess(string result) => _onSuccess(result);
+    public void OnError(string error) => _onError(error);
+}
+#endif
+```
+
+### Use in Your Page
+
+```csharp
+public partial class MainPage : ContentPage
+{
+    public MainPage() { InitializeComponent(); }
+
+    private void OnSyncButtonClicked(object sender, EventArgs e)
+    {
+#if ANDROID
+        var version = DotnetMyBinding.GetVersion();
+        var result = DotnetMyBinding.ProcessData("test input");
+        DisplayAlert("Result", $"Version: {version}\nResult: {result}", "OK");
+#endif
+    }
+
+    private void OnAsyncButtonClicked(object sender, EventArgs e)
+    {
+#if ANDROID
+        DotnetMyBinding.FetchDataAsync("my query", new MyDataCallback(
+            onSuccess: result => MainThread.BeginInvokeOnMainThread(() => 
+                DisplayAlert("Success", result, "OK")),
+            onError: error => MainThread.BeginInvokeOnMainThread(() => 
+                DisplayAlert("Error", error, "OK"))
+        ));
+#endif
+    }
+}
+```
+
+### Register Event Listener
+
+```csharp
+#if ANDROID
+public class MyEventListener : Java.Lang.Object, DotnetMyBinding.IEventListener
+{
+    private readonly Action<string, string> _onEvent;
+
+    public MyEventListener(Action<string, string> onEvent) { _onEvent = onEvent; }
+
+    public void OnEvent(string eventType, string eventData)
+    {
+        MainThread.BeginInvokeOnMainThread(() => _onEvent(eventType, eventData));
+    }
+}
+
+// In your page
+protected override void OnAppearing()
+{
+    base.OnAppearing();
+    DotnetMyBinding.SetEventListener(new MyEventListener((type, data) =>
+    {
+        StatusLabel.Text = $"Event: {type} - {data}";
+    }));
+}
+
+protected override void OnDisappearing()
+{
+    base.OnDisappearing();
+    DotnetMyBinding.RemoveEventListener();
+}
+#endif
+```
+
+## Updating Bindings When Native SDK Changes
+
+### 1. Update Native Dependency Version
+
+Edit `app/build.gradle.kts`:
+```kotlin
+dependencies {
+    implementation("com.thirdparty:awesomelib:2.0.0")  // Updated version
+}
+```
+
+### 2. Re-analyze Dependencies
+
+```bash
+cd android/native
+./gradlew app:dependencies --configuration releaseRuntimeClasspath
+```
+
+Compare with your previous dependency mapping and identify new, changed, and removed dependencies.
+
+### 3. Update the Wrapper (If Needed)
+
+Review release notes and update `DotnetMyBinding.java`:
+- Add new methods for new APIs
+- Update method signatures for changed APIs
+- Remove deprecated API wrappers
+
+### 4. Rebuild the AAR
+
+```bash
+./gradlew :app:assembleRelease
+```
+
+### 5. Update Binding Project Dependencies
+
+Update NuGet packages and Maven dependencies in the binding `.csproj`.
+
+### 6. Rebuild and Fix Errors
+
+```bash
+cd ../MyBinding.Android.Binding
+dotnet build
+```
+
+### 7. Update Metadata.xml (If Needed)
+
+If new classes/methods were added, update parameter names and namespace mappings.
+
+### 8. Test
+
+Build and run the sample app to verify functionality.
+
+## Handling Native Libraries (.so files)
+
+Some Android libraries include native code (`.so` files). If you get `java.lang.UnsatisfiedLinkError`, ensure native libraries are properly included.
+
+### Including .so Files
+
+For AAR files, `.so` files are usually included automatically. For JAR files, add them manually:
+
+```xml
+<ItemGroup>
+  <AndroidNativeLibrary Include="libs\arm64-v8a\libmynative.so">
+    <Abi>arm64-v8a</Abi>
+  </AndroidNativeLibrary>
+  <AndroidNativeLibrary Include="libs\armeabi-v7a\libmynative.so">
+    <Abi>armeabi-v7a</Abi>
+  </AndroidNativeLibrary>
+  <AndroidNativeLibrary Include="libs\x86_64\libmynative.so">
+    <Abi>x86_64</Abi>
+  </AndroidNativeLibrary>
+</ItemGroup>
+```
+
+### Manually Loading Native Libraries
+
+```csharp
+Java.Lang.JavaSystem.LoadLibrary("mynative");
+```
+
+## Troubleshooting
+
+### Build Errors
+
+#### "Java dependency 'X' is not satisfied" (XA4241/XA4242)
+
+Missing transitive dependency. Follow the dependency resolution decision tree:
+1. If XA4242 suggests a NuGet package → Install it
+2. If you don't need the API in C# → Use `AndroidMavenLibrary` with `Bind="false"`
+3. If it's compile-time only → Use `AndroidIgnoredJavaDependency`
+
+#### "Type is defined multiple times"
+
+Duplicate classes from including the same dependency twice. Check for overlap between NuGet packages and AAR contents. Use `Bind="false"` or remove redundant references.
+
+#### "Class 'X' does not implement interface member 'Y'"
+
+Covariant return types or interface implementation issues. Add custom implementation in `Additions/` folder:
+
+```csharp
+namespace Com.Example
+{
+    public partial class MyClass
+    {
+        Java.Lang.Object SomeInterface.SomeMethod()
+        {
+            return RawSomeMethod();
+        }
+    }
+}
+```
+
+#### "Cannot find symbol" / "Package does not exist"
+
+Wrapper code references classes not available. Verify all dependencies are declared in `build.gradle.kts` and rebuild the AAR.
+
+#### Gradle Build Failures
+
+```bash
+./gradlew clean
+./gradlew :app:assembleRelease --stacktrace
+```
+
+### Runtime Errors
+
+#### `Java.Lang.NoClassDefFoundError`
+
+Missing dependency at runtime. A required dependency was ignored. Remove it from `AndroidIgnoredJavaDependency` and properly satisfy it.
+
+#### `Java.Lang.UnsatisfiedLinkError`
+
+Native library (.so) not loaded:
+1. Ensure .so files are included in the AAR
+2. Call `JavaSystem.LoadLibrary()` if needed
+3. Check ABI compatibility (arm64-v8a, armeabi-v7a, x86_64)
+
+#### `Java.Lang.IllegalStateException: Must call initialize() first`
+
+Ensure you call `DotnetMyBinding.Initialize()` before using other methods.
+
+#### Callback Not Invoked
+
+1. **Callback on wrong thread** — Use `MainThread.BeginInvokeOnMainThread()` for UI updates
+2. **Callback garbage collected** — Store a strong reference to the callback object
+3. **Exception in native code** — Add try/catch in wrapper and check logcat
+
+### IntelliSense Issues
+
+IntelliSense shows errors but project compiles — this is normal for binding projects. The binding generator doesn't use source generators. Build the project first and IntelliSense will catch up.
+
+## Callback Interface Pattern
+
+```java
+// Java - define a simple callback interface
+public interface DataCallback {
+    void onSuccess(String result);
+    void onError(String error);
+}
+```
+
+```csharp
+// C# - implement the generated interface
+public class MyCallback : Java.Lang.Object, DotnetMyBinding.IDataCallback
+{
+    private readonly Action<string> _onSuccess;
+    private readonly Action<string> _onError;
+
+    public MyCallback(Action<string> onSuccess, Action<string> onError)
+    {
+        _onSuccess = onSuccess;
+        _onError = onError;
+    }
+
+    public void OnSuccess(string result) => _onSuccess(result);
+    public void OnError(string error) => _onError(error);
+}
+```
+
+## Complete Script: Create Android Binding Project
+
+```bash
+#!/bin/bash
+set -e
+
+# Configuration
+BINDING_NAME="${1:-MyBinding}"
+PACKAGE_NAME="${2:-com.example.mybinding}"
+MIN_SDK="${3:-21}"
+GRADLE_VERSION="${4:-9.2.1}"
+AGP_VERSION="${5:-8.2.2}"
+
+echo "Creating Android binding project: ${BINDING_NAME}"
+echo "  Package: ${PACKAGE_NAME}"
+echo "  Min SDK: ${MIN_SDK}"
+echo "  Gradle: ${GRADLE_VERSION}"
+
+# Create directory structure
+mkdir -p ${BINDING_NAME}/android/native/app/src/main/java/${PACKAGE_NAME//./\/}
+mkdir -p ${BINDING_NAME}/android/${BINDING_NAME}.Android.Binding/Transforms
+mkdir -p ${BINDING_NAME}/sample/MauiSample
+
+cd ${BINDING_NAME}/android/native
+
+# Download and setup Gradle Wrapper
+echo "Setting up Gradle Wrapper..."
+mkdir -p gradle/wrapper
+cat > gradle/wrapper/gradle-wrapper.properties << EOF
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+EOF
+
+cat > gradlew << 'GRADLEW_EOF'
+#!/bin/sh
+exec java -jar "$(dirname "$0")/gradle/wrapper/gradle-wrapper.jar" "$@"
+GRADLEW_EOF
+chmod +x gradlew
+
+curl -sL -o gradle/wrapper/gradle-wrapper.jar \
+  "https://raw.githubusercontent.com/gradle/gradle/v${GRADLE_VERSION}/gradle/wrapper/gradle-wrapper.jar" 2>/dev/null || \
+  echo "Note: Could not download gradle-wrapper.jar. Run './gradlew' to auto-download."
+
+# Create settings.gradle.kts
+cat > settings.gradle.kts << EOF
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "${BINDING_NAME}Native"
+include(":app")
+EOF
+
+cat > build.gradle.kts << EOF
+plugins {
+    id("com.android.library") version "${AGP_VERSION}" apply false
+}
+EOF
+
+cat > app/build.gradle.kts << EOF
+plugins {
+    id("com.android.library")
+}
+
+android {
+    namespace = "${PACKAGE_NAME}"
+    compileSdk = 34
+    defaultConfig { minSdk = ${MIN_SDK} }
+    buildTypes { release { isMinifyEnabled = false } }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core:1.12.0")
+}
+EOF
+
+# Create Java wrapper
+cat > app/src/main/java/${PACKAGE_NAME//./\/}/Dotnet${BINDING_NAME}.java << EOF
+package ${PACKAGE_NAME};
+
+import android.content.Context;
+import android.util.Log;
+
+public class Dotnet${BINDING_NAME} {
+    private static final String TAG = "Dotnet${BINDING_NAME}";
+    private static boolean initialized = false;
+
+    public static void initialize(Context context, boolean debug) {
+        if (initialized) return;
+        initialized = true;
+        Log.d(TAG, "${BINDING_NAME} initialized");
+    }
+
+    public static boolean isInitialized() { return initialized; }
+    public static String getVersion() { return "1.0.0"; }
+    
+    public interface DataCallback {
+        void onSuccess(String result);
+        void onError(String error);
+    }
+    
+    public static void fetchDataAsync(String query, DataCallback callback) {
+        if (!initialized) { callback.onError("Not initialized"); return; }
+        callback.onSuccess("Result for: " + query);
+    }
+}
+EOF
+
+cd ../..
+
+dotnet new androidbinding -n ${BINDING_NAME}.Android.Binding -o ${BINDING_NAME}.Android.Binding
+
+cat > ${BINDING_NAME}.Android.Binding/Transforms/Metadata.xml << EOF
+<metadata>
+  <attr path="/api/package[@name='${PACKAGE_NAME}']" 
+        name="managedName">${BINDING_NAME}</attr>
+</metadata>
+EOF
+
+cd ..
+
+echo ""
+echo "✅ Created ${BINDING_NAME} Android binding project!"
+echo ""
+echo "Next steps:"
+echo "  1. cd ${BINDING_NAME}/android/native"
+echo "  2. Add your native library to app/build.gradle.kts"
+echo "  3. ./gradlew :app:assembleRelease"
+echo "  4. cd ../${BINDING_NAME}.Android.Binding"
+echo "  5. dotnet build"
+echo "  6. Resolve any dependency errors"
+```
+
+Usage:
+```bash
+chmod +x create-android-binding.sh
+./create-android-binding.sh MyAwesomeBinding
+./create-android-binding.sh MyAwesomeBinding com.mycompany.mybinding 21 9.2.1 8.2.2
+```

--- a/.claude/skills/ios-slim-bindings/SKILL.md
+++ b/.claude/skills/ios-slim-bindings/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: ios-slim-bindings
+description: Create and update slim/native platform interop bindings for iOS in .NET MAUI and .NET for iOS projects. Guides through creating Swift/Objective-C wrappers, configuring Xcode projects, generating C# API definitions, and integrating native iOS libraries using the Native Library Interop (NLI) approach. Use when asked about iOS bindings, xcframework integration, Swift interop, Objective Sharpie, or bridging native iOS SDKs to .NET.
+---
+
+# When to use this skill
+
+Activate this skill when the user asks:
+- How do I create iOS bindings for a native library?
+- How do I wrap an iOS SDK for use in .NET MAUI?
+- How do I create slim bindings for iOS?
+- How do I use Native Library Interop for iOS?
+- How do I bind a Swift library to .NET?
+- How do I use Objective Sharpie for iOS bindings?
+- How do I integrate an xcframework into .NET MAUI?
+- How do I create a Swift wrapper for a native iOS library?
+- How do I update iOS bindings when the native SDK changes?
+- How do I fix iOS binding build errors?
+- How do I expose native iOS APIs to C#?
+- How do I handle CocoaPods dependencies in iOS bindings?
+- How do I handle Swift Package Manager dependencies?
+
+# Overview
+
+This skill guides the creation of **Native Library Interop (Slim Bindings)** for iOS. This modern approach creates a thin native Swift/Objective-C wrapper exposing only the APIs you need from a native iOS library, making bindings easier to create and maintain.
+
+## When to Use Slim Bindings vs Traditional Bindings
+
+| Scenario | Recommended Approach |
+|----------|---------------------|
+| Need only a subset of library functionality | **Slim Bindings** |
+| Easier maintenance when SDK updates | **Slim Bindings** |
+| Prefer working in Swift/Objective-C for wrapper | **Slim Bindings** |
+| Better isolation from breaking changes | **Slim Bindings** |
+| Need entire library API surface | Traditional Bindings |
+| Creating bindings for third-party developers | Traditional Bindings |
+| Already maintaining traditional bindings | Traditional Bindings |
+
+# Inputs
+
+| Parameter | Required | Example | Notes |
+|-----------|----------|---------|-------|
+| libraryName | yes | `FirebaseMessaging`, `Lottie` | Name of the native iOS library to bind |
+| bindingProjectName | yes | `MyBinding.MaciOS` | Name for the C# binding project |
+| dependencySource | no | `cocoapods`, `spm`, `xcframework` | How the native library is distributed |
+| targetFrameworks | no | `net9.0-ios;net9.0-maccatalyst` | Target frameworks (default: latest .NET iOS + Mac Catalyst) |
+| exposedApis | no | List of specific APIs | Which native APIs to expose (helps scope the wrapper) |
+
+# Project Structure
+
+```
+MyBinding/
+ macios/
+ native/   
+ MyBinding/                    # Xcode project      
+ MyBinding.xcodeproj/          
+ project.pbxproj             
+ MyBinding/          
+ DotnetMyBinding.swift  # Swift wrapper implementation             
+ Podfile                    # If using CocoaPods          
+ Package.swift              # If using Swift Package Manager          
+ MyBinding.MaciOS.Binding/   
+ MyBinding.MaciOS.Binding.csproj       
+ ApiDefinition.cs       
+ sample/
+ MauiSample/                        # Sample MAUI app   
+ MauiSample.csproj       
+ MainPage.xaml.cs       
+ README.md
+```
+
+# Step-by-step Process
+
+> **For detailed code examples and full implementation walkthroughs, see [references/ios-slim-bindings-implementation.md](references/ios-slim-bindings-implementation.md).**
+
+## Step 1: Create Project Structure
+
+Install XcodeGen (`brew install xcodegen`) and create the directory structure:
+
+```bash
+BINDING_NAME="MyBinding"
+mkdir -p ${BINDING_NAME}/macios/native/${BINDING_NAME}/${BINDING_NAME}
+mkdir -p ${BINDING_NAME}/macios/${BINDING_NAME}.MaciOS.Binding
+```
+
+## Step 2: Create the Xcode Project
+
+Create a `project.yml` for XcodeGen with framework target, then run `xcodegen generate`. Key build settings:
+
+- `BUILD_LIBRARY_FOR_DISTRIBUTION: YES`
+- `MACH_O_TYPE: staticlib`
+- `DEFINES_MODULE: YES`
+- `SWIFT_VERSION: "5.0"`
+
+## Step 3: Create the C# Binding Project
+
+Create a `.csproj` with `<IsBindingProject>true</IsBindingProject>` and reference the Xcode project:
+
+```xml
+<XcodeProject Include="../native/MyBinding/MyBinding.xcodeproj">
+  <SchemeName>MyBinding</SchemeName>
+</XcodeProject>
+```
+
+Create an initial `ApiDefinition.cs` with `[BaseType]`, `[Static]`, and `[Export]` attributes.
+
+## Step 4: Build and Verify
+
+```bash
+dotnet build
+```
+
+This invokes XcodeBuild, creates the xcframework, and generates the C# binding assembly.
+
+## Step 5: Add Native Library Dependencies
+
+Choose the appropriate method:
+
+| Method | When to Use |
+|--------|-------------|
+| **CocoaPods** | Library distributed via CocoaPods. Use `use_frameworks! :linkage => :static`. After `pod install`, reference `.xcworkspace` instead of `.xcodeproj`. |
+| **Swift Package Manager** | Library distributed via SPM. Add via Xcode UI or `Package.swift`. |
+| **Manual XCFramework** | Pre-built xcframework. Drag into Xcode project, set "Do Not Embed" for static linking. |
+
+## Step 6: Implement the Swift Wrapper
+
+Create `DotnetMyBinding.swift` with these requirements:
+
+- All classes must inherit from `NSObject` and have `@objc(ClassName)` annotation
+- All methods must be `public` with `@objc(selector:)` annotation
+- Use only Objective-C compatible types (see Type Mapping table below)
+- Use completion handlers `(Result?, NSError?) -> Void` for async operations
+- Convert all errors to `NSError` for proper propagation to C#
+
+## Step 7: Generate ApiDefinition.cs
+
+After building, find the generated Swift header and use Objective Sharpie:
+
+```bash
+sharpie bind --output=sharpie-output --namespace=MyBinding --sdk=iphoneos18.0 \
+  --scope=Headers "path/to/MyBinding-Swift.h"
+```
+
+Clean up the generated output: add `[Async]` attributes, `[NullAllowed]` for nullable types, remove `[Verify]` attributes after review, and remove `InitWithCoder` constructors.
+
+## Step 8: Build the Final Binding
+
+```bash
+dotnet build -c Release
+```
+
+## Step 9: Use in Your MAUI App
+
+Add a conditional `<ProjectReference>`, initialize in `MauiProgram.cs` with `#if IOS || MACCATALYST`, and use `[Async]`-generated methods with `await`.
+
+# Updating Bindings When Native SDK Changes
+
+1. Update native dependency version (CocoaPods: `pod update`, SPM: update version, or replace xcframework)
+2. Update Swift wrapper if APIs changed
+3. Clean and rebuild: `dotnet clean && dotnet build`
+4. Regenerate Objective Sharpie output and diff with existing `ApiDefinition.cs`
+5. Merge changes: add new bindings, update signatures, preserve custom attributes.
+6. Test with sample app
+
+> For detailed update instructions, see [references/ios-slim-bindings-implementation.md](references/ios-slim-bindings-implementation.md).
+
+# Troubleshooting
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "Framework not found" | XCFramework path incorrect or missing architectures | Verify path in `<XcodeProject>`, check `lipo -info` |
+| "Undefined symbols for architecture" | Missing linked frameworks or symbol visibility | Add system frameworks, verify `public` + `@objc` annotations |
+| "No type or protocol named" | Missing import or protocol mismatch | Add `using` directives, use interface types |
+| "Duplicate symbol" | Multiple framework references | Remove duplicates, resolve version conflicts |
+| "Native class hasn't been loaded" (runtime) | Framework not embedded or missing `@objc` | Set `<ForceLoad>true</ForceLoad>`, check annotations |
+| "unrecognized selector" (runtime) | Selector mismatch between C# and Swift | Verify `[Export("...")]` matches `@objc(...)` exactly |
+| "Library not loaded: @rpath" (runtime) | Swift runtime or embedding issue | Add linker flags, set "Embed & Sign" for dynamic frameworks |
+| Callbacks not working | Wrong thread, GC'd reference, or missing `@escaping` | Use `DispatchQueue.main.async`, hold strong reference |
+
+> For detailed troubleshooting with code examples, see [references/ios-slim-bindings-implementation.md](references/ios-slim-bindings-implementation.md).
+
+# Quick Reference
+
+## Swift Wrapper Annotation Requirements
+
+```swift
+@objc(ClassName)
+public class ClassName: NSObject {
+    @objc(methodNameWithParam:anotherParam:)
+    public func methodName(param: String, anotherParam: Int) -> Bool { ... }
+
+    @objc(staticMethodWithValue:)
+    public static func staticMethod(value: String) -> String { ... }
+}
+```
+
+## Type Mapping
+
+| Swift Type | Objective-C Type | C# Type |
+|------------|------------------|---------|
+| `String` | `NSString *` | `string` |
+| `Bool` | `BOOL` | `bool` |
+| `Int`, `Int32` | `int` | `int` |
+| `Int64` | `long long` | `long` |
+| `Double` | `double` | `double` |
+| `Float` | `float` | `float` |
+| `Data` | `NSData *` | `NSData` |
+| `[String: Any]` | `NSDictionary *` | `NSDictionary` |
+| `[Any]` | `NSArray *` | `NSArray` |
+| `UIView` | `UIView *` | `UIView` |
+| `UIImage` | `UIImage *` | `UIImage` |
+| `URL` | `NSURL *` | `NSUrl` |
+| Custom Class | Must inherit `NSObject` | Interface with `[BaseType]` |
+| `(Result, Error?) -> Void` | Block | `Action<Result?, NSError?>` |
+
+## ApiDefinition Attributes
+
+| Attribute | Purpose |
+|-----------|---------|
+| `[BaseType(typeof(NSObject))]` | Specifies base class |
+| `[Static]` | Static method/property |
+| `[Export("selector:")]` | Objective-C selector |
+| `[Async]` | Generate async wrapper for completion handler methods |
+| `[NullAllowed]` | Nullable parameter/return |
+| `[Protocol]` | Objective-C protocol |
+| `[Model]` | Protocol implementation |
+| `[Abstract]` | Required protocol method |
+| `[Internal]` | Don't expose publicly |
+| `[Sealed]` | Prevent subclassing |
+
+## XcodeProject MSBuild Properties
+
+| Property | Description | Default |
+|----------|-------------|---------|
+| `SchemeName` | Xcode scheme to build | Required |
+| `Configuration` | Build configuration | `Release` |
+| `Kind` | `Framework` or `Static` | Auto-detected |
+| `SmartLink` | Enable smart linking | `true` |
+| `ForceLoad` | Force load all symbols | `false` |
+
+# Resources
+
+## Official Documentation
+- [Native Library Interop - .NET Community Toolkit](https://learn.microsoft.com/dotnet/communitytoolkit/maui/native-library-interop)
+- [iOS Binding Project Migration](https://learn.microsoft.com/dotnet/maui/migration/ios-binding-projects)
+- [Binding Objective-C Libraries](https://learn.microsoft.com/xamarin/cross-platform/macios/binding/)
+- [Objective Sharpie](https://learn.microsoft.com/previous-versions/xamarin/cross-platform/macios/binding/objective-sharpie/)
+
+## Tools
+- [XcodeGen](https://github.com/yonaskolb/XcodeGen) — Generate Xcode projects from YAML specification
+
+## Templates and Examples
+- [Maui.NativeLibraryInterop Repository](https://github.com/CommunityToolkit/Maui.NativeLibraryInterop)
+- [CommunityToolkit.Maui Bindings](https://github.com/CommunityToolkit/Maui)
+
+## Reference Files
+- [ios-bindings-guide.md](references/ios-bindings-guide.md) — comprehensive binding reference
+- [ios-slim-bindings-implementation.md](references/ios-slim-bindings-implementation.md) — detailed code examples, troubleshooting, and complete scripts
+- For Android bindings, use the **android-slim-bindings** skill
+
+# Output Format
+
+When assisting with iOS slim bindings, provide:
+
+1. **Project structure** - File/folder layout for the binding
+2. **Swift wrapper code** - Complete `DotnetMyBinding.swift` implementation
+3. **Xcode configuration** - Build settings and dependency setup
+4. **C# binding project** - `.csproj` and `ApiDefinition.cs` files
+5. **Usage examples** - How to call the binding from MAUI/C#
+6. **Troubleshooting guidance** - Common issues and solutions for the specific library
+
+Always verify:
+- Swift classes have `@objc(ClassName)` annotations
+- Methods have `@objc(selector:)` annotations matching Objective-C conventions
+- Types are marshallable between Swift and C#
+- Async operations use completion handlers with `[Async]` attribute
+- Error handling uses `NSError` for proper propagation

--- a/.claude/skills/ios-slim-bindings/references/ios-bindings-guide.md
+++ b/.claude/skills/ios-slim-bindings/references/ios-bindings-guide.md
@@ -1,0 +1,641 @@
+# Creating Bindings for .NET iOS Projects
+
+This guide covers the process of creating C# bindings to interface with native iOS platform libraries (xcframeworks) in .NET MAUI, .NET for iOS, and .NET for Mac Catalyst projects.
+
+## Overview
+
+When you need to use a third-party iOS library not written in C#, you must create a **binding** that exposes the native API to .NET. There are two primary approaches:
+
+1. **Traditional Full Bindings** - Bind the entire native library's API surface using Objective Sharpie
+2. **Native Library Interop (Slim Bindings)** - Create a thin native wrapper exposing only the APIs you need
+
+---
+
+## Approach Comparison
+
+### When to Use Traditional Full Bindings
+
+- You need access to the majority of a library's API surface
+- You're a vendor creating bindings for third-party developers
+- You're already maintaining traditional bindings and comfortable with the workflow
+- The library has a stable API that doesn't change frequently
+
+### When to Use Native Library Interop (Slim Bindings)
+
+- You only need a small subset of the library's functionality
+- You want easier maintenance when the underlying SDK updates
+- You prefer working in native languages (Swift/Objective-C) for the wrapper implementation
+- You want better isolation from breaking changes in the underlying SDK
+
+---
+
+## Traditional Full Bindings
+
+This approach binds the entire native library directly, generating C# interfaces for all public APIs.
+
+### Prerequisites
+
+- .NET 9 SDK (or your target .NET version)
+- Xcode and Xcode Command Line Tools
+- Objective Sharpie (requires Xamarin.iOS legacy installation)
+- macOS development environment
+
+### Step 1: Create the Binding Project
+
+```bash
+dotnet new iosbinding -n "MyLibrary.iOS"
+```
+
+This generates three files:
+- `MyLibrary.iOS.csproj` - Project configuration
+- `ApiDefinition.cs` - C# interface definitions
+- `StructsAndEnums.cs` - Enumerations and structures
+
+### Step 2: Prepare the Native Framework
+
+Most modern iOS libraries are distributed as XCFrameworks. If you have source code, you'll need to build it into an XCFramework.
+
+#### Building from Source (Swift Library Example)
+
+1. Open the Xcode project/workspace
+2. Navigate to **Build Settings**
+3. Set **Mach-O Type** to **Static Library**
+4. Set **Build Libraries for Distribution** to **Yes**
+5. Set **Skip Install** to **No**
+
+Build for iOS device:
+```bash
+xcodebuild archive \
+  -scheme "YourScheme" \
+  -destination 'generic/platform=iOS' \
+  -archivePath ./build/YourLibrary \
+  SKIP_INSTALL=NO \
+  BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+```
+
+Build for iOS Simulator:
+```bash
+xcodebuild archive \
+  -scheme "YourScheme" \
+  -destination 'generic/platform=iOS Simulator' \
+  -archivePath ./build/YourLibrarySim \
+  SKIP_INSTALL=NO \
+  BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+```
+
+Create the XCFramework:
+```bash
+xcodebuild -create-xcframework \
+  -framework ./build/YourLibrary.xcarchive/Products/Library/Frameworks/YourLibrary.framework \
+  -framework ./build/YourLibrarySim.xcarchive/Products/Library/Frameworks/YourLibrary.framework \
+  -output ./build/YourLibrary.xcframework
+```
+
+### Step 3: Configure the Binding Project
+
+Add the native reference to your `.csproj`:
+
+```xml
+<ItemGroup>
+  <ObjcBindingApiDefinition Include="ApiDefinition.cs"/>
+  <ObjcBindingCoreSource Include="StructsAndEnums.cs"/>
+</ItemGroup>
+
+<ItemGroup>
+  <NativeReference Include="YourLibrary.xcframework">
+    <Kind>Framework</Kind>
+    <Frameworks>Foundation UIKit CoreGraphics</Frameworks>
+  </NativeReference>
+</ItemGroup>
+```
+
+#### NativeReference Properties
+
+| Property | Description |
+|----------|-------------|
+| `Kind` | `Framework` for .framework/.xcframework, `Static` for .a files |
+| `Frameworks` | Space-separated list of Apple frameworks the library depends on |
+| `LinkerFlags` | Additional linker flags (e.g., Swift library paths) |
+| `SmartLink` | Enable/disable smart linking (default: true) |
+| `ForceLoad` | Force load all symbols (use if symbols missing at runtime) |
+
+Example with Swift support:
+```xml
+<NativeReference Include="YourLibrary.xcframework">
+  <Kind>Framework</Kind>
+  <Frameworks>Foundation UIKit</Frameworks>
+  <LinkerFlags>-L "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos" -Wl,-rpath -Wl,@executable_path/Frameworks</LinkerFlags>
+  <SmartLink>False</SmartLink>
+  <ForceLoad>True</ForceLoad>
+</NativeReference>
+```
+
+### Step 4: Generate Bindings with Objective Sharpie
+
+Install Objective Sharpie:
+```bash
+brew install --cask objectivesharpie
+```
+
+Check available SDKs:
+```bash
+sharpie xcode -sdks
+```
+
+Generate bindings:
+```bash
+sharpie bind \
+  --sdk=iphoneos18.1 \
+  --output=SharpieOutput \
+  --namespace=YourNamespace \
+  --framework=/path/to/YourLibrary.xcframework/ios-arm64/YourLibrary.framework
+```
+
+For header files specifically:
+```bash
+sharpie bind \
+  --sdk=iphoneos18.1 \
+  --output=SharpieOutput \
+  --namespace=YourNamespace \
+  --scope=Headers \
+  Headers/YourLibrary-Swift.h
+```
+
+### Step 5: Clean Up Generated Bindings
+
+Objective Sharpie generates code that often requires manual cleanup:
+
+#### Common Issues to Fix
+
+1. **Namespace Addition** - Add your namespace to both generated files
+
+2. **Remove Problematic InitWithCoder**
+   ```csharp
+   // REMOVE these - they conflict with linker-added methods
+   [Export("initWithCoder:")]
+   NativeHandle Constructor(NSCoder coder);
+   ```
+
+3. **Fix Protocol/Interface Type Mismatches**
+   ```csharp
+   // Change concrete types to interfaces where needed
+   // Before: CAAnimation animation
+   // After: ICAAnimation animation
+   ```
+
+4. **Handle Verify Attributes** - Review and remove `[Verify]` attributes after confirming correctness
+
+#### ApiDefinition.cs Structure
+
+```csharp
+using System;
+using Foundation;
+using UIKit;
+using ObjCRuntime;
+
+namespace YourNamespace
+{
+    // @interface YourClass : NSObject
+    [BaseType(typeof(NSObject))]
+    interface YourClass
+    {
+        // -(void)doSomething;
+        [Export("doSomething")]
+        void DoSomething();
+
+        // @property (nonatomic, strong) NSString *name;
+        [Export("name", ArgumentSemantic.Strong)]
+        string Name { get; set; }
+
+        // +(instancetype)sharedInstance;
+        [Static]
+        [Export("sharedInstance")]
+        YourClass SharedInstance { get; }
+    }
+
+    // @protocol YourDelegate <NSObject>
+    [Protocol, Model]
+    [BaseType(typeof(NSObject))]
+    interface YourDelegate
+    {
+        // @optional -(void)didComplete:(BOOL)success;
+        [Export("didComplete:")]
+        void DidComplete(bool success);
+    }
+}
+```
+
+### Step 6: Build and Package
+
+```bash
+dotnet build MyLibrary.iOS.csproj -c Release
+```
+
+The NuGet package will be in `bin/Release/`.
+
+---
+
+## Native Library Interop (Slim Bindings)
+
+This modern approach creates a thin native wrapper exposing only the APIs you need.
+
+### Project Structure
+
+```
+MyBinding/
+├── macios/
+│   ├── native/
+│   │   └── MyBinding/           # Xcode project
+│   │       ├── MyBinding.xcodeproj
+│   │       └── MyBinding/
+│   │           └── DotnetMyBinding.swift
+│   └── MyBinding.MaciOS.Binding/
+│       ├── MyBinding.MaciOS.Binding.csproj
+│       └── ApiDefinition.cs
+└── sample/
+    └── MauiSample/              # Sample app
+```
+
+### Step 1: Set Up Using the Template
+
+Clone the Community Toolkit template:
+```bash
+git clone https://github.com/CommunityToolkit/Maui.NativeLibraryInterop
+cp -r Maui.NativeLibraryInterop/template ./MyBinding
+```
+
+### Step 2: Configure the Xcode Wrapper Project
+
+The native wrapper is located at `macios/native/NewBinding/`.
+
+#### Add Native Dependencies
+
+You can add dependencies via:
+- **CocoaPods**: Add to Podfile and run `pod install`
+- **Swift Package Manager**: Add through Xcode's package dependencies
+- **Manual**: Drag xcframeworks into the project
+
+#### Create the Wrapper API
+
+Edit `DotnetNewBinding.swift`:
+
+```swift
+import Foundation
+import UIKit
+import TheNativeLibrary  // Your native library
+
+@objc(MauiMyBinding)
+public class MauiMyBinding : NSObject {
+    
+    @objc(initialize)
+    public static func initialize() {
+        TheNativeLibrary.configure()
+    }
+    
+    @objc(doSomethingWithValue:completion:)
+    public static func doSomething(
+        value: String,
+        completion: @escaping (String?, NSError?) -> Void
+    ) {
+        TheNativeLibrary.process(value) { result, error in
+            completion(result, error as NSError?)
+        }
+    }
+    
+    @objc(createViewWithFrame:)
+    public static func createView(frame: CGRect) -> UIView {
+        return TheNativeLibrary.createCustomView(frame: frame)
+    }
+}
+```
+
+**Key Requirements:**
+- Classes must be `public` and annotated with `@objc(ClassName)`
+- Methods must be `public` and annotated with `@objc(methodName:parameter:)`
+- Use only types .NET already knows: `NSObject`, `NSData`, `NSError`, `String`, `UIView`, primitives
+- Callbacks should use `@escaping` completion handlers
+
+### Step 3: Configure the Binding Project
+
+The `.csproj` uses `XcodeProject` instead of `NativeReference`:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <IsBindingProject>true</IsBindingProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <XcodeProject Include="../native/MyBinding/MyBinding.xcodeproj">
+      <SchemeName>MyBinding</SchemeName>
+      <!-- Optional: Override defaults -->
+      <!-- <Kind>Framework</Kind> -->
+      <!-- <SmartLink>true</SmartLink> -->
+    </XcodeProject>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+  </ItemGroup>
+</Project>
+```
+
+### Step 4: Generate and Update ApiDefinition.cs
+
+Build the binding project first:
+```bash
+dotnet build
+```
+
+Then run Objective Sharpie on the generated xcframework:
+```bash
+sharpie bind \
+  --output=sharpie-out \
+  --namespace=MyBindingMaciOS \
+  --sdk=iphoneos18.0 \
+  --scope=Headers \
+  Headers/MyBinding-Swift.h
+```
+
+The generated header is located at:
+```
+bin/Debug/net9.0-ios/MyBinding.MaciOS.Binding.resources/MyBindingiOS.xcframework/ios-arm64/MyBinding.framework/Headers/MyBinding-Swift.h
+```
+
+Update `ApiDefinition.cs`:
+
+```csharp
+using System;
+using Foundation;
+using ObjCRuntime;
+using UIKit;
+
+namespace MyBinding
+{
+    // @interface MauiMyBinding : NSObject
+    [BaseType(typeof(NSObject))]
+    interface MauiMyBinding
+    {
+        // +(void)initialize;
+        [Static]
+        [Export("initialize")]
+        void Initialize();
+
+        // +(void)doSomethingWithValue:(NSString *)value completion:(void (^)(NSString *, NSError *))completion;
+        [Static]
+        [Export("doSomethingWithValue:completion:")]
+        [Async]  // Generates async/await version
+        void DoSomething(string value, Action<string?, NSError?> completion);
+
+        // +(UIView *)createViewWithFrame:(CGRect)frame;
+        [Static]
+        [Export("createViewWithFrame:")]
+        UIView CreateView(CGRect frame);
+    }
+}
+```
+
+### Step 5: Reference in Your App
+
+Add to your MAUI app's `.csproj`:
+
+```xml
+<!-- Reference to MaciOS Binding project -->
+<ItemGroup Condition="$(TargetFramework.Contains('ios')) Or $(TargetFramework.Contains('maccatalyst'))">
+  <ProjectReference Include="..\..\macios\MyBinding.MaciOS.Binding\MyBinding.MaciOS.Binding.csproj" />
+</ItemGroup>
+```
+
+### Step 6: Use in Your App
+
+```csharp
+#if IOS || MACCATALYST
+using MyBinding;
+#endif
+
+public partial class MainPage : ContentPage
+{
+    public MainPage()
+    {
+        InitializeComponent();
+        
+#if IOS || MACCATALYST
+        MauiMyBinding.Initialize();
+#endif
+    }
+
+    private async void OnButtonClicked(object sender, EventArgs e)
+    {
+#if IOS || MACCATALYST
+        try
+        {
+            // Using the async version (generated by [Async] attribute)
+            var result = await MauiMyBinding.DoSomethingAsync("test");
+            await DisplayAlert("Result", result, "OK");
+        }
+        catch (NSErrorException ex)
+        {
+            await DisplayAlert("Error", ex.Error.LocalizedDescription, "OK");
+        }
+#endif
+    }
+}
+```
+
+---
+
+## Handling Native Dependencies
+
+### Understanding Dependency Types
+
+1. **System Frameworks** - Apple's built-in frameworks (Foundation, UIKit, etc.)
+2. **Third-Party Frameworks** - External xcframeworks/frameworks
+3. **Static Libraries** - `.a` files
+4. **Swift Runtime** - Required for Swift-based libraries
+
+### Declaring System Framework Dependencies
+
+In traditional bindings, list all required frameworks:
+
+```xml
+<NativeReference Include="MyLibrary.xcframework">
+  <Kind>Framework</Kind>
+  <Frameworks>Foundation UIKit CoreGraphics CoreImage QuartzCore AVFoundation</Frameworks>
+</NativeReference>
+```
+
+**Finding Dependencies:**
+- Check the native library's documentation
+- Look at the Xcode project's "Link Binary with Libraries" build phase
+- Review `Package.swift` for Swift packages
+- Check the podspec for CocoaPods
+
+### Handling Third-Party Dependencies
+
+#### Option 1: Vendor Dependencies (Include in Binding)
+
+For static libraries, dependencies can be statically linked into your wrapper:
+
+```swift
+// In your Xcode project, ensure dependencies are linked statically
+// Check Build Settings > Mach-O Type = Static Library
+```
+
+#### Option 2: Separate Bindings for Each Dependency
+
+Create separate binding projects for each dependency:
+
+```xml
+<!-- In your main app project -->
+<ItemGroup Condition="$(TargetFramework.Contains('ios'))">
+  <ProjectReference Include="..\Bindings\MyLibrary.iOS\MyLibrary.iOS.csproj" />
+  <ProjectReference Include="..\Bindings\DependencyA.iOS\DependencyA.iOS.csproj" />
+  <ProjectReference Include="..\Bindings\DependencyB.iOS\DependencyB.iOS.csproj" />
+</ItemGroup>
+```
+
+#### Option 3: CocoaPods in Native Wrapper (Slim Bindings)
+
+For Native Library Interop, dependencies can be managed in the Xcode wrapper project:
+
+```ruby
+# Podfile in macios/native/MyBinding/
+platform :ios, '15.0'
+
+target 'MyBinding' do
+  use_frameworks! :linkage => :static
+  
+  pod 'FirebaseMessaging', '~> 10.0'
+  pod 'SomeOtherLibrary'
+end
+```
+
+### Swift Runtime Considerations
+
+Swift libraries require the Swift runtime. Add linker flags:
+
+```xml
+<NativeReference Include="SwiftLibrary.xcframework">
+  <Kind>Framework</Kind>
+  <Frameworks>Foundation UIKit</Frameworks>
+  <LinkerFlags>
+    -L "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos"
+    -L "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator"
+    -Wl,-rpath -Wl,@executable_path/Frameworks
+  </LinkerFlags>
+</NativeReference>
+```
+
+---
+
+## Troubleshooting Common Issues
+
+### Build Errors
+
+#### "Framework not found"
+- Verify the xcframework path is correct
+- Check that all architectures are included (arm64 for device, x86_64/arm64 for simulator)
+- Ensure `Kind` is set correctly (`Framework` vs `Static`)
+
+#### "Undefined symbols"
+- Add missing frameworks to the `<Frameworks>` element
+- Try setting `<ForceLoad>True</ForceLoad>`
+- Check if the library requires Swift runtime support
+
+#### "No type or protocol named..."
+- Review ApiDefinition.cs for incorrect type mappings
+- Protocol types should use interfaces (e.g., `ICAAnimation` not `CAAnimation`)
+
+### Runtime Errors
+
+#### "Native class hasn't been loaded"
+- Ensure the xcframework is properly embedded
+- Try setting `<SmartLink>False</SmartLink>` and `<ForceLoad>True</ForceLoad>`
+- Verify the binding project builds successfully
+
+#### "Library not loaded: @rpath/..."
+- Add appropriate linker flags for Swift runtime
+- Check that all dependencies are properly linked
+- Verify the framework is embedded (not just linked)
+
+### IntelliSense Not Working
+
+This is expected behavior for binding projects:
+- Binding projects don't use source generators
+- Build the binding project first, then reload the solution
+- The app will compile even if IntelliSense shows errors
+
+---
+
+## Best Practices
+
+### API Design for Slim Bindings
+
+1. **Keep wrapper APIs simple** - Use only primitive types and types .NET knows
+2. **Use completion handlers** - Better than synchronous calls for async operations
+3. **Return UIView** - For native views that need to be displayed
+4. **Handle errors properly** - Convert errors to NSError for proper propagation
+
+### Maintenance
+
+1. **Version your bindings** - Use semantic versioning matching the native library
+2. **Document dependencies** - List all required frameworks and their versions
+3. **Test on real devices** - Simulator-only testing may miss linking issues
+4. **Keep wrappers thin** - Don't add business logic to the native wrapper
+
+### Project Organization
+
+```
+Solution/
+├── src/
+│   └── MyApp/
+│       └── MyApp.csproj
+├── bindings/
+│   ├── ios/
+│   │   ├── native/           # Xcode wrapper projects
+│   │   └── MyLibrary.iOS/    # Binding projects
+│   └── android/
+│       └── ...
+└── MyApp.sln
+```
+
+---
+
+## Resources
+
+- [Maui.NativeLibraryInterop Repository](https://github.com/CommunityToolkit/Maui.NativeLibraryInterop)
+- [Native Library Interop Documentation](https://learn.microsoft.com/dotnet/communitytoolkit/maui/native-library-interop)
+- [Objective Sharpie Documentation](https://learn.microsoft.com/previous-versions/xamarin/cross-platform/macios/binding/objective-sharpie/)
+- [iOS Binding Project Migration Guide](https://learn.microsoft.com/dotnet/maui/migration/ios-binding-projects)
+
+---
+
+## Quick Reference: ApiDefinition Attributes
+
+| Attribute | Usage |
+|-----------|-------|
+| `[BaseType(typeof(NSObject))]` | Base class for the interface |
+| `[Static]` | Static method or property |
+| `[Export("selector:")]` | Objective-C selector mapping |
+| `[Async]` | Generate async wrapper for completion handler methods |
+| `[Protocol]` | Marks an Objective-C protocol |
+| `[Model]` | Protocol implementation base class |
+| `[Abstract]` | Required protocol method |
+| `[NullAllowed]` | Parameter or return value can be null |
+| `[Internal]` | Don't expose publicly |
+
+## Quick Reference: NativeReference Options
+
+```xml
+<NativeReference Include="Library.xcframework">
+  <Kind>Framework|Static</Kind>
+  <Frameworks>Space separated framework names</Frameworks>
+  <LinkerFlags>Additional linker flags</LinkerFlags>
+  <SmartLink>true|false</SmartLink>
+  <ForceLoad>true|false</ForceLoad>
+  <IsCxx>true|false</IsCxx>
+</NativeReference>
+```

--- a/.claude/skills/ios-slim-bindings/references/ios-slim-bindings-implementation.md
+++ b/.claude/skills/ios-slim-bindings/references/ios-slim-bindings-implementation.md
@@ -1,0 +1,965 @@
+# iOS Slim Bindings — Detailed Implementation Guide
+
+This reference contains detailed code examples, step-by-step instructions, troubleshooting, and complete scripts for creating iOS slim bindings. For the high-level workflow overview, see the main [SKILL.md](../SKILL.md).
+
+---
+
+## Step 1: Create Project Structure from Command Line
+
+### Prerequisites
+
+Install XcodeGen (generates Xcode projects from YAML):
+
+```bash
+brew install xcodegen
+```
+
+### Create Directory Structure
+
+```bash
+BINDING_NAME="MyBinding"
+
+mkdir -p ${BINDING_NAME}/macios/native/${BINDING_NAME}/${BINDING_NAME}
+mkdir -p ${BINDING_NAME}/macios/${BINDING_NAME}.MaciOS.Binding
+mkdir -p ${BINDING_NAME}/sample/MauiSample
+
+cd ${BINDING_NAME}
+```
+
+## Step 2: Create the Xcode Project with XcodeGen
+
+### Create the XcodeGen Project Spec
+
+Create `macios/native/${BINDING_NAME}/project.yml`:
+
+```yaml
+name: MyBinding
+options:
+  bundleIdPrefix: com.example
+  deploymentTarget:
+    iOS: "15.0"
+    macOS: "12.0"
+  xcodeVersion: "15.0"
+  generateEmptyDirectories: true
+
+settings:
+  base:
+    MARKETING_VERSION: "1.0.0"
+    CURRENT_PROJECT_VERSION: "1"
+    BUILD_LIBRARY_FOR_DISTRIBUTION: YES
+    SKIP_INSTALL: NO
+    MACH_O_TYPE: staticlib
+    SWIFT_VERSION: "5.0"
+    ENABLE_BITCODE: NO
+    DEFINES_MODULE: YES
+
+targets:
+  MyBinding:
+    type: framework
+    platform: iOS
+    sources:
+      - path: MyBinding
+        type: group
+    settings:
+      base:
+        INFOPLIST_FILE: MyBinding/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.mybinding
+        PRODUCT_NAME: MyBinding
+        TARGETED_DEVICE_FAMILY: "1,2"
+    scheme:
+      gatherCoverageData: false
+      shared: true
+```
+
+### Create the Swift Source File
+
+```bash
+cat > macios/native/${BINDING_NAME}/${BINDING_NAME}/Dotnet${BINDING_NAME}.swift << 'EOF'
+import Foundation
+import UIKit
+
+@objc(DotnetMyBinding)
+public class DotnetMyBinding: NSObject {
+    
+    @objc(initialize)
+    public static func initialize() {
+        print("MyBinding initialized")
+    }
+    
+    @objc(getVersion)
+    public static func getVersion() -> String {
+        return "1.0.0"
+    }
+    
+    @objc(fetchDataWithQuery:completion:)
+    public static func fetchData(
+        query: String,
+        completion: @escaping (String?, NSError?) -> Void
+    ) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            completion("Result for: \(query)", nil)
+        }
+    }
+    
+    @objc(createViewWithFrame:)
+    public static func createView(frame: CGRect) -> UIView {
+        let view = UIView(frame: frame)
+        view.backgroundColor = .systemBlue
+        return view
+    }
+}
+EOF
+```
+
+### Create Info.plist
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>NSPrincipalClass</key>
+    <string></string>
+</dict>
+</plist>
+```
+
+### Generate the Xcode Project
+
+```bash
+cd macios/native/${BINDING_NAME}
+xcodegen generate
+cd ../../..
+```
+
+## Step 3: Create the C# Binding Project
+
+### Create the Binding .csproj
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <IsBindingProject>true</IsBindingProject>
+    <PackageId>MyBinding.MaciOS</PackageId>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <XcodeProject Include="../native/MyBinding/MyBinding.xcodeproj">
+      <SchemeName>MyBinding</SchemeName>
+    </XcodeProject>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+  </ItemGroup>
+</Project>
+```
+
+### Create Initial ApiDefinition.cs
+
+```csharp
+using System;
+using Foundation;
+using ObjCRuntime;
+using UIKit;
+
+namespace MyBinding
+{
+    [BaseType(typeof(NSObject))]
+    interface DotnetMyBinding
+    {
+        [Static]
+        [Export("initialize")]
+        void Initialize();
+
+        [Static]
+        [Export("getVersion")]
+        string GetVersion();
+
+        [Static]
+        [Export("fetchDataWithQuery:completion:")]
+        [Async]
+        void FetchData(string query, Action<string?, NSError?> completion);
+
+        [Static]
+        [Export("createViewWithFrame:")]
+        UIView CreateView(CGRect frame);
+    }
+}
+```
+
+## Step 4: Build and Verify
+
+```bash
+cd macios/${BINDING_NAME}.MaciOS.Binding
+dotnet build
+```
+
+Verify the output:
+```bash
+find bin -name "*.xcframework" -type d
+find bin -name "*-Swift.h" -type f
+```
+
+## CocoaPods Support
+
+### Create Podfile
+
+```ruby
+platform :ios, '15.0'
+
+target 'MyBinding' do
+  use_frameworks! :linkage => :static
+  
+  # pod 'FirebaseMessaging', '~> 10.0'
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
+    end
+  end
+end
+```
+
+### Install Pods
+
+```bash
+cd macios/native/${BINDING_NAME}
+pod install
+cd ../../..
+
+# Update the binding project to use xcworkspace instead of xcodeproj
+sed -i '' 's/\.xcodeproj/\.xcworkspace/g' macios/${BINDING_NAME}.MaciOS.Binding/${BINDING_NAME}.MaciOS.Binding.csproj
+```
+
+## Swift Package Manager Support
+
+```swift
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "MyBinding",
+    platforms: [.iOS(.v15), .macCatalyst(.v15)],
+    products: [
+        .library(name: "MyBinding", type: .static, targets: ["MyBinding"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/example/SomeLibrary.git", from: "1.0.0")
+    ],
+    targets: [
+        .target(
+            name: "MyBinding",
+            dependencies: [
+                .product(name: "SomeLibrary", package: "SomeLibrary")
+            ]
+        )
+    ]
+)
+```
+
+## Full Swift Wrapper Example
+
+```swift
+import Foundation
+import UIKit
+import TheNativeLibrary
+
+@objc(DotnetMyBinding)
+public class DotnetMyBinding: NSObject {
+    
+    // MARK: - Initialization
+    
+    @objc(initializeWithApiKey:)
+    public static func initialize(apiKey: String) {
+        TheNativeLibrary.configure(withApiKey: apiKey)
+    }
+    
+    @objc(isInitialized)
+    public static func isInitialized() -> Bool {
+        return TheNativeLibrary.isConfigured
+    }
+    
+    // MARK: - Synchronous Methods
+    
+    @objc(getVersion)
+    public static func getVersion() -> String {
+        return TheNativeLibrary.version
+    }
+    
+    @objc(processDataWithInput:)
+    public static func processData(input: String) -> String? {
+        guard let result = TheNativeLibrary.process(input) else { return nil }
+        return result.stringValue
+    }
+    
+    // MARK: - Asynchronous Methods
+    
+    @objc(fetchDataWithQuery:completion:)
+    public static func fetchData(
+        query: String,
+        completion: @escaping (String?, NSError?) -> Void
+    ) {
+        TheNativeLibrary.fetch(query: query) { result in
+            switch result {
+            case .success(let data):
+                completion(data.stringValue, nil)
+            case .failure(let error):
+                completion(nil, error as NSError)
+            }
+        }
+    }
+    
+    @objc(performOperationWithConfig:completion:)
+    public static func performOperation(
+        config: NSDictionary,
+        completion: @escaping (NSData?, NSError?) -> Void
+    ) {
+        guard let configDict = config as? [String: Any] else {
+            let error = NSError(
+                domain: "DotnetMyBinding", code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid configuration"]
+            )
+            completion(nil, error)
+            return
+        }
+        TheNativeLibrary.performOperation(config: configDict) { result in
+            switch result {
+            case .success(let data): completion(data, nil)
+            case .failure(let error): completion(nil, error as NSError)
+            }
+        }
+    }
+    
+    // MARK: - View Creation
+    
+    @objc(createViewWithFrame:)
+    public static func createView(frame: CGRect) -> UIView {
+        let nativeView = TheNativeLibrary.createCustomView()
+        nativeView.frame = frame
+        return nativeView
+    }
+    
+    @objc(createViewWithFrame:options:)
+    public static func createView(frame: CGRect, options: NSDictionary) -> UIView {
+        let config = options as? [String: Any] ?? [:]
+        let nativeView = TheNativeLibrary.createCustomView(options: config)
+        nativeView.frame = frame
+        return nativeView
+    }
+    
+    // MARK: - Delegate/Callback Pattern
+    
+    private static var callbackHandler: ((String) -> Void)?
+    
+    @objc(registerCallbackWithHandler:)
+    public static func registerCallback(handler: @escaping (String) -> Void) {
+        callbackHandler = handler
+        TheNativeLibrary.setEventHandler { event in
+            callbackHandler?(event.description)
+        }
+    }
+    
+    @objc(unregisterCallback)
+    public static func unregisterCallback() {
+        callbackHandler = nil
+        TheNativeLibrary.setEventHandler(nil)
+    }
+}
+```
+
+### Completion Handler Pattern
+
+```swift
+// Swift
+@objc(operationWithInput:completion:)
+public static func operation(
+    input: String,
+    completion: @escaping (String?, NSError?) -> Void
+) {
+    DispatchQueue.main.async {
+        completion(result, nil)    // Success
+        // OR
+        completion(nil, error as NSError)  // Failure
+    }
+}
+```
+
+```csharp
+// C# ApiDefinition.cs - Add [Async] for automatic async wrapper
+[Static]
+[Export("operationWithInput:completion:")]
+[Async]
+void Operation(string input, Action<string?, NSError?> completion);
+
+// Usage
+var result = await DotnetMyBinding.OperationAsync("input");
+```
+
+### Error Handling Pattern
+
+```swift
+@objc(riskyOperationWithCompletion:)
+public static func riskyOperation(completion: @escaping (Bool, NSError?) -> Void) {
+    do {
+        try TheNativeLibrary.riskyOperation()
+        completion(true, nil)
+    } catch {
+        let nsError = NSError(
+            domain: "DotnetMyBinding",
+            code: (error as NSError).code,
+            userInfo: [
+                NSLocalizedDescriptionKey: error.localizedDescription,
+                NSUnderlyingErrorKey: error
+            ]
+        )
+        completion(false, nsError)
+    }
+}
+```
+
+## Full C# Binding Project (Alternative .csproj)
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <IsBindingProject>true</IsBindingProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <XcodeProject Include="../native/MyBinding/MyBinding.xcodeproj">
+      <SchemeName>MyBinding</SchemeName>
+    </XcodeProject>
+  </ItemGroup>
+
+  <!-- If using xcworkspace (CocoaPods) -->
+  <!--
+  <ItemGroup>
+    <XcodeProject Include="../native/MyBinding/MyBinding.xcworkspace">
+      <SchemeName>MyBinding</SchemeName>
+    </XcodeProject>
+  </ItemGroup>
+  -->
+
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+  </ItemGroup>
+</Project>
+```
+
+### XcodeProject Properties
+
+| Property | Description | Default |
+|----------|-------------|---------|
+| `SchemeName` | Xcode scheme to build | Required |
+| `Configuration` | Build configuration | `Release` |
+| `Kind` | `Framework` or `Static` | Auto-detected |
+| `SmartLink` | Enable smart linking | `true` |
+| `ForceLoad` | Force load all symbols | `false` |
+
+## Generate ApiDefinition.cs with Objective Sharpie
+
+### Install Objective Sharpie
+
+```bash
+brew install --cask objectivesharpie
+```
+
+### Check Available SDKs
+
+```bash
+sharpie xcode -sdks
+```
+
+### Generate Bindings
+
+```bash
+HEADER_PATH="bin/Debug/net9.0-ios/MyBinding.MaciOS.Binding.resources/MyBindingiOS.xcframework/ios-arm64/MyBinding.framework/Headers/MyBinding-Swift.h"
+SDK_VERSION="iphoneos18.0"
+NAMESPACE="MyBinding"
+
+sharpie bind \
+  --output=sharpie-output \
+  --namespace=$NAMESPACE \
+  --sdk=$SDK_VERSION \
+  --scope=Headers \
+  "$HEADER_PATH"
+```
+
+### Full ApiDefinition.cs Example
+
+```csharp
+using System;
+using Foundation;
+using ObjCRuntime;
+using UIKit;
+
+namespace MyBinding
+{
+    [BaseType(typeof(NSObject))]
+    interface DotnetMyBinding
+    {
+        [Static]
+        [Export("initializeWithApiKey:")]
+        void Initialize(string apiKey);
+
+        [Static]
+        [Export("isInitialized")]
+        bool IsInitialized { get; }
+
+        [Static]
+        [Export("getVersion")]
+        string GetVersion();
+
+        [Static]
+        [Export("processDataWithInput:")]
+        [return: NullAllowed]
+        string ProcessData(string input);
+
+        [Static]
+        [Export("fetchDataWithQuery:completion:")]
+        [Async]
+        void FetchData(string query, Action<string?, NSError?> completion);
+
+        [Static]
+        [Export("performOperationWithConfig:completion:")]
+        [Async]
+        void PerformOperation(NSDictionary config, Action<NSData?, NSError?> completion);
+
+        [Static]
+        [Export("createViewWithFrame:")]
+        UIView CreateView(CGRect frame);
+
+        [Static]
+        [Export("createViewWithFrame:options:")]
+        UIView CreateView(CGRect frame, NSDictionary options);
+
+        [Static]
+        [Export("registerCallbackWithHandler:")]
+        void RegisterCallback(Action<string> handler);
+
+        [Static]
+        [Export("unregisterCallback")]
+        void UnregisterCallback();
+    }
+}
+```
+
+### Common Cleanup Tasks
+
+| Issue | Solution |
+|-------|----------|
+| Missing namespace | Add `namespace MyBinding { ... }` |
+| `[Verify]` attributes | Review each, remove after confirming correctness |
+| `InitWithCoder` constructors | Remove — conflicts with linker |
+| Protocol type mismatches | Use interface types (e.g., `ICAAnimation`) |
+| Missing `[NullAllowed]` | Add for nullable parameters/returns |
+| Completion handlers | Add `[Async]` attribute for async generation |
+
+## Use in Your MAUI App
+
+### Add Project Reference
+
+```xml
+<ItemGroup Condition="$(TargetFramework.Contains('ios')) Or $(TargetFramework.Contains('maccatalyst'))">
+  <ProjectReference Include="..\..\macios\MyBinding.MaciOS.Binding\MyBinding.MaciOS.Binding.csproj" />
+</ItemGroup>
+```
+
+### Initialize in MauiProgram.cs
+
+```csharp
+using Microsoft.Maui.Hosting;
+
+#if IOS || MACCATALYST
+using MyBinding;
+#endif
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder.UseMauiApp<App>();
+
+#if IOS || MACCATALYST
+        DotnetMyBinding.Initialize("your-api-key");
+#endif
+
+        return builder.Build();
+    }
+}
+```
+
+### Use Async APIs
+
+```csharp
+#if IOS || MACCATALYST
+using MyBinding;
+#endif
+
+public partial class MainPage : ContentPage
+{
+    private async void OnFetchClicked(object sender, EventArgs e)
+    {
+#if IOS || MACCATALYST
+        try
+        {
+            var result = await DotnetMyBinding.FetchDataAsync("my query");
+            await DisplayAlert("Success", result ?? "No data", "OK");
+        }
+        catch (NSErrorException ex)
+        {
+            await DisplayAlert("Error", ex.Error.LocalizedDescription, "OK");
+        }
+#endif
+    }
+
+    private void OnCreateViewClicked(object sender, EventArgs e)
+    {
+#if IOS || MACCATALYST
+        var nativeView = DotnetMyBinding.CreateView(new CoreGraphics.CGRect(0, 0, 300, 200));
+#endif
+    }
+}
+```
+
+### Register Callbacks
+
+```csharp
+#if IOS || MACCATALYST
+protected override void OnAppearing()
+{
+    base.OnAppearing();
+    DotnetMyBinding.RegisterCallback((message) =>
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            StatusLabel.Text = $"Event: {message}";
+        });
+    });
+}
+
+protected override void OnDisappearing()
+{
+    base.OnDisappearing();
+    DotnetMyBinding.UnregisterCallback();
+}
+#endif
+```
+
+## Updating Bindings When Native SDK Changes
+
+### 1. Update Native Dependency Version
+
+**CocoaPods:**
+```ruby
+pod 'FirebaseMessaging', '~> 11.0'
+```
+```bash
+cd macios/native/MyBinding
+pod update
+```
+
+**Swift Package Manager:** Update version in Xcode's Package Dependencies or `Package.swift`.
+
+**Manual XCFramework:** Replace the xcframework file with the new version.
+
+### 2. Update Swift Wrapper (If Needed)
+
+Review release notes and update `DotnetMyBinding.swift`:
+- Add new methods for new APIs
+- Update method signatures for changed APIs
+- Remove deprecated API wrappers
+
+### 3. Regenerate API Definition
+
+```bash
+cd macios/MyBinding.MaciOS.Binding
+dotnet clean
+dotnet build
+
+sharpie bind \
+  --output=sharpie-output-new \
+  --namespace=MyBinding \
+  --sdk=iphoneos18.0 \
+  --scope=Headers \
+  "bin/Debug/net9.0-ios/MyBinding.MaciOS.Binding.resources/MyBindingiOS.xcframework/ios-arm64/MyBinding.framework/Headers/MyBinding-Swift.h"
+```
+
+### 4. Diff and Merge Changes
+
+```bash
+diff ApiDefinition.cs sharpie-output-new/ApiDefinitions.cs
+```
+
+Manually merge: add new bindings, update changed signatures, remove deleted methods, preserve custom attributes.
+
+### 5. Test the Updated Bindings
+
+```bash
+dotnet build -c Release
+dotnet test
+```
+
+## Troubleshooting
+
+### Build Errors
+
+#### "Framework not found" / "Library not found"
+
+1. **XCFramework path incorrect** — Verify the path in `<XcodeProject>` or `<NativeReference>`
+2. **Missing architectures** — Ensure xcframework includes arm64 (device) and arm64/x86_64 (simulator)
+3. **CocoaPods not installed** — Run `pod install` in the native directory
+
+```bash
+lipo -info path/to/Framework.framework/Framework
+```
+
+#### "Undefined symbols for architecture"
+
+1. **Missing linked frameworks** — Add system frameworks to Xcode project's "Link Binary with Libraries"
+2. **Static vs Dynamic mismatch** — Ensure consistent linkage
+3. **Symbol visibility** — Verify Swift classes/methods are `public` and have `@objc`
+
+```xml
+<XcodeProject Include="...">
+  <SchemeName>MyBinding</SchemeName>
+  <ForceLoad>true</ForceLoad>
+  <SmartLink>false</SmartLink>
+</XcodeProject>
+```
+
+#### "No type or protocol named..."
+
+1. **Missing import** — Add required imports to `ApiDefinition.cs`
+2. **Protocol vs Interface** — Use interface types (`ICAAnimation` not `CAAnimation`)
+3. **Namespace mismatch** — Verify namespace matches
+
+#### "Duplicate symbol" / "Symbol already defined"
+
+1. **Multiple references to same framework** — Check for duplicate entries
+2. **Conflicting dependency versions** — Resolve CocoaPods/SPM version conflicts
+3. **InitWithCoder constructor** — Remove from ApiDefinition.cs
+
+#### Objective Sharpie Errors
+
+**"Unable to find SDK":**
+```bash
+sharpie xcode -sdks
+xcode-select --install
+sudo xcode-select -s /Applications/Xcode.app
+```
+
+**"Parse error in header":**
+- Simplify the Swift wrapper to use basic types
+- Use `--scope=Headers` to limit parsing
+
+### Runtime Errors
+
+#### "Native class hasn't been loaded"
+
+1. **Framework not embedded** — Check native resources are included in app bundle
+2. **Static library not linked** — Verify `<ForceLoad>true</ForceLoad>` is set
+3. **Missing Objective-C class registration** — Ensure `@objc(ClassName)` annotation is present
+
+#### "unrecognized selector sent to instance"
+
+1. **Selector mismatch** — Verify `[Export("selector:")]` matches Swift `@objc(selector:)` exactly
+2. **Method signature mismatch** — Check parameter count and types
+3. **Static vs instance method** — Ensure `[Static]` attribute is correct
+
+#### "Library not loaded: @rpath/..."
+
+1. **Swift runtime missing** — Add linker flags for Swift libraries
+2. **Framework not embedded** — Set "Embed & Sign" in Xcode for dynamic frameworks
+3. **rpath not set** — Add `-Wl,-rpath -Wl,@executable_path/Frameworks`
+
+#### Callbacks Not Working
+
+1. **Callback on wrong thread** — Use `DispatchQueue.main.async` in Swift
+2. **Callback garbage collected** — Store strong reference to handler
+3. **Missing `@escaping`** — Completion handlers must be `@escaping` in Swift
+
+### IntelliSense Issues
+
+IntelliSense shows errors but project compiles — this is expected. Binding projects don't use source generators. Build first, then reload the solution.
+
+## NativeReference MSBuild Properties (Traditional Bindings)
+
+```xml
+<NativeReference Include="Library.xcframework">
+  <Kind>Framework</Kind>
+  <Frameworks>Foundation UIKit</Frameworks>
+  <LinkerFlags>-lsqlite3</LinkerFlags>
+  <SmartLink>true</SmartLink>
+  <ForceLoad>false</ForceLoad>
+  <IsCxx>false</IsCxx>
+</NativeReference>
+```
+
+## Using the Community Toolkit Template (Alternative)
+
+```bash
+git clone https://github.com/CommunityToolkit/Maui.NativeLibraryInterop
+cp -r Maui.NativeLibraryInterop/template ./MyBinding
+cd MyBinding
+
+find . -name "*NewBinding*" -exec bash -c 'mv "$0" "${0//NewBinding/MyBinding}"' {} \;
+find . -type f \( -name "*.cs" -o -name "*.csproj" -o -name "*.swift" -o -name "*.yml" \) | xargs sed -i '' 's/NewBinding/MyBinding/g'
+```
+
+The template includes pre-configured Xcode project, binding .csproj, sample MAUI app, and CI/CD workflows.
+
+## Complete Script: Create iOS Binding Project
+
+```bash
+#!/bin/bash
+set -e
+
+BINDING_NAME="${1:-MyBinding}"
+BUNDLE_ID_PREFIX="${2:-com.example}"
+MIN_IOS_VERSION="${3:-15.0}"
+
+echo "Creating iOS binding project: ${BINDING_NAME}"
+
+if ! command -v xcodegen &> /dev/null; then
+    echo "Installing xcodegen..."
+    brew install xcodegen
+fi
+
+mkdir -p ${BINDING_NAME}/macios/native/${BINDING_NAME}/${BINDING_NAME}
+mkdir -p ${BINDING_NAME}/macios/${BINDING_NAME}.MaciOS.Binding
+cd ${BINDING_NAME}
+
+# Create XcodeGen project spec
+cat > macios/native/${BINDING_NAME}/project.yml << EOF
+name: ${BINDING_NAME}
+options:
+  bundleIdPrefix: ${BUNDLE_ID_PREFIX}
+  deploymentTarget:
+    iOS: "${MIN_IOS_VERSION}"
+    macOS: "12.0"
+settings:
+  base:
+    BUILD_LIBRARY_FOR_DISTRIBUTION: YES
+    SKIP_INSTALL: NO
+    MACH_O_TYPE: staticlib
+    SWIFT_VERSION: "5.0"
+    DEFINES_MODULE: YES
+targets:
+  ${BINDING_NAME}:
+    type: framework
+    platform: iOS
+    sources:
+      - path: ${BINDING_NAME}
+        type: group
+    settings:
+      base:
+        INFOPLIST_FILE: ${BINDING_NAME}/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: ${BUNDLE_ID_PREFIX}.${BINDING_NAME,,}
+        PRODUCT_NAME: ${BINDING_NAME}
+    scheme:
+      shared: true
+EOF
+
+# Create Swift wrapper
+cat > macios/native/${BINDING_NAME}/${BINDING_NAME}/Dotnet${BINDING_NAME}.swift << EOF
+import Foundation
+import UIKit
+
+@objc(Dotnet${BINDING_NAME})
+public class Dotnet${BINDING_NAME}: NSObject {
+    @objc(initialize) public static func initialize() { print("${BINDING_NAME} initialized") }
+    @objc(getVersion) public static func getVersion() -> String { return "1.0.0" }
+}
+EOF
+
+# Create Info.plist
+cat > macios/native/${BINDING_NAME}/${BINDING_NAME}/Info.plist << 'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key><string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key><string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key><string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+    <key>CFBundleName</key><string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key><string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key><string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key><string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>
+EOF
+
+cd macios/native/${BINDING_NAME}
+xcodegen generate
+cd ../../..
+
+# Create binding .csproj
+cat > macios/${BINDING_NAME}.MaciOS.Binding/${BINDING_NAME}.MaciOS.Binding.csproj << EOF
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <IsBindingProject>true</IsBindingProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <XcodeProject Include="../native/${BINDING_NAME}/${BINDING_NAME}.xcodeproj">
+      <SchemeName>${BINDING_NAME}</SchemeName>
+    </XcodeProject>
+  </ItemGroup>
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+  </ItemGroup>
+</Project>
+EOF
+
+# Create ApiDefinition.cs
+cat > macios/${BINDING_NAME}.MaciOS.Binding/ApiDefinition.cs << EOF
+using Foundation;
+namespace ${BINDING_NAME}
+{
+    [BaseType(typeof(NSObject))]
+    interface Dotnet${BINDING_NAME}
+    {
+        [Static] [Export("initialize")] void Initialize();
+        [Static] [Export("getVersion")] string GetVersion();
+    }
+}
+EOF
+
+echo "✅ Created ${BINDING_NAME} binding project!"
+```
+
+Usage:
+```bash
+chmod +x create-ios-binding.sh
+./create-ios-binding.sh MyAwesomeBinding com.mycompany 15.0
+```


### PR DESCRIPTION
Add comprehensive skill documentation and reference guides for Android and iOS "slim" (Native Library Interop) bindings under .claude/skills. Files added include SKILL.md entries and detailed reference implementation and guide documents that cover project structure, dependency analysis, Gradle/Maven and NuGet mapping, wrapper examples (Java/Kotlin), binding project configuration, Metadata.xml transforms, native .so handling, troubleshooting, and usage examples.

Added files:
- .claude/skills/android-slim-bindings/SKILL.md
- .claude/skills/android-slim-bindings/references/android-bindings-guide.md
- .claude/skills/android-slim-bindings/references/android-slim-bindings-implementation.md
- .claude/skills/ios-slim-bindings/SKILL.md
- .claude/skills/ios-slim-bindings/references/ios-bindings-guide.md
- .claude/skills/ios-slim-bindings/references/ios-slim-bindings-implementation.md

These docs provide step-by-step workflows, examples, and troubleshooting guidance to help developers create and maintain lightweight platform interop bindings for .NET MAUI and platform-specific projects.