### PR TITLE
Update RevenueCat native SDKs

### DIFF
--- a/android/RevenueCat.Android.Binding/RevenueCat.Android.Binding.csproj
+++ b/android/RevenueCat.Android.Binding/RevenueCat.Android.Binding.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<RevenueCatSdkVersion>9.19.1</RevenueCatSdkVersion>
+		<RevenueCatSdkVersion>9.29.0</RevenueCatSdkVersion>
 		<RevenueCatSdkUrl>https://repo1.maven.org/maven2/com/revenuecat/purchases/purchases/$(RevenueCatSdkVersion)/purchases-$(RevenueCatSdkVersion).aar</RevenueCatSdkUrl>
 		<RevenueCatUISdkUrl>https://repo1.maven.org/maven2/com/revenuecat/purchases/purchases-ui/$(RevenueCatSdkVersion)/purchases-ui-$(RevenueCatSdkVersion).aar</RevenueCatUISdkUrl>
 	</PropertyGroup>

--- a/android/native/revenuecatbinding/build.gradle.kts
+++ b/android/native/revenuecatbinding/build.gradle.kts
@@ -31,11 +31,10 @@ dependencies {
     // Uncomment line below and replace {dependency.name.goes.here} with your dependency
     // implementation("{dependency.name.goes.here}")
 
-    implementation("com.revenuecat.purchases:purchases:9.19.1")
-    implementation("com.revenuecat.purchases:purchases-store-amazon:9.19.1")
+    implementation("com.revenuecat.purchases:purchases:9.29.0")
+    implementation("com.revenuecat.purchases:purchases-store-amazon:9.29.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3")
-//    implementation("com.revenuecat.purchases:purchases-ui:8.16.0")
+//    implementation("com.revenuecat.purchases:purchases-ui:9.29.0")
     implementation("com.google.code.gson:gson:2.12.0")
 
 }
-

--- a/macios/RevenueCat.MaciOS.Binding/RevenueCat.MaciOS.Binding.csproj
+++ b/macios/RevenueCat.MaciOS.Binding/RevenueCat.MaciOS.Binding.csproj
@@ -31,7 +31,7 @@
 			-->
 		</XcodeProject>
 
-		<NativeReference Include="../native/bin/deps/RevenueCat/RevenueCat.xcframework">
+		<NativeReference Include="../native/bin/deps/RevenueCat.xcframework">
 			<Kind>Framework</Kind>
 			<SmartLink>true</SmartLink>
 			<ForceLoad>true</ForceLoad>
@@ -121,13 +121,13 @@
 	
 	<Target Name="DownloadNativeDependencies" BeforeTargets="Build" Condition=" '$(IsCrossTargetingBuild)' == 'true' ">
 		<PropertyGroup>
-			<RevenueCatSdkVersion>5.55.2</RevenueCatSdkVersion>
+			<RevenueCatSdkVersion>5.67.1</RevenueCatSdkVersion>
 
 			<RevenueCatSdkUrl>https://github.com/RevenueCat/purchases-ios/releases/download/$(RevenueCatSdkVersion)/RevenueCat.xcframework.zip</RevenueCatSdkUrl>
 			
 			<_RevenueCatDownloadPath>$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)))/../native/bin/deps</_RevenueCatDownloadPath>
-			<_RevenueCatFrameworkPListFilePath>$(_RevenueCatDownloadPath)/RevenueCat/RevenueCat.xcframework/Info.plist</_RevenueCatFrameworkPListFilePath>
-			<_RevenueCatXcFrameworkPath>$(_RevenueCatDownloadPath)/RevenueCat/RevenueCat.xcframework</_RevenueCatXcFrameworkPath>
+			<_RevenueCatXcFrameworkPath>$(_RevenueCatDownloadPath)/RevenueCat.xcframework</_RevenueCatXcFrameworkPath>
+			<_RevenueCatFrameworkPListFilePath>$(_RevenueCatXcFrameworkPath)/Info.plist</_RevenueCatFrameworkPListFilePath>
 		</PropertyGroup>
 
 		<DownloadFile SourceUrl="$(RevenueCatSdkUrl)" DestinationFolder="$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)/../native/bin/deps))">
@@ -144,7 +144,7 @@
 			<_RevenueCatUnwantedPlatforms Include="watchos-arm64_i386_x86_64-simulator" />
 		</ItemGroup>
 		
-		<Exec Command="codesign --deep --remove-signature $(_RevenueCatDownloadPath)/RevenueCat/RevenueCat.xcframework" />
+		<Exec Command="codesign --deep --remove-signature $(_RevenueCatXcFrameworkPath)" ContinueOnError="true" />
 		
 		<!-- Remove vision and watchos to save space -->
 		<RemoveDir Directories="$(_RevenueCatXcFrameworkPath)/%(_RevenueCatUnwantedPlatforms.Identity)" />

--- a/macios/native/RevenueCatBinding/RevenueCatBinding.xcodeproj/project.pbxproj
+++ b/macios/native/RevenueCatBinding/RevenueCatBinding.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		646070982D42CC940036C905 /* RevenueCat.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RevenueCat.xcframework; path = ../bin/deps/RevenueCat/RevenueCat.xcframework; sourceTree = "<group>"; };
+		646070982D42CC940036C905 /* RevenueCat.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RevenueCat.xcframework; path = ../bin/deps/RevenueCat.xcframework; sourceTree = "<group>"; };
 		83E34F532C21CB2B008AA950 /* RevenueCatBinding.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RevenueCatBinding.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		83E34F562C21CB2B008AA950 /* RevenueCat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RevenueCat.h; sourceTree = "<group>"; };
 		83E34F5D2C21CC53008AA950 /* RevenueCatBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevenueCatBinding.swift; sourceTree = "<group>"; };


### PR DESCRIPTION
## Summary

- update the Android RevenueCat native SDK from `9.19.1` to `9.29.0`
- update the iOS/macCatalyst RevenueCat native SDK from `5.55.2` to `5.67.1`
- adjust the Apple binding dependency download/build path for the current `RevenueCat.xcframework` layout
- make the xcframework signature-removal step resilient so newer upstream archives still build cleanly

## Validation

- `dotnet build RevenueCat.sln`
- `dotnet build ./Plugin.RevenueCat/Plugin.RevenueCat.csproj -f net10.0-android`
- `dotnet build ./Plugin.RevenueCat.Api/Plugin.RevenueCat.Api.csproj`
- `dotnet build ./Plugin.RevenueCat.Core/Plugin.RevenueCat.Core.csproj`
- `./gradlew :revenuecatbinding:clean :revenuecatbinding:assembleRelease`
- `dotnet build -m:1 -t:DownloadNativeDependencies ./macios/RevenueCat.MaciOS.Binding/RevenueCat.MaciOS.Binding.csproj`
- `dotnet build ./macios/RevenueCat.MaciOS.Binding/RevenueCat.MaciOS.Binding.csproj`

## Notes

- `dotnet test ./Tests/Tests.csproj` is still environment-gated and requires the existing `AppSettings:ApiKeyV1` / `AppSettings:ApiKeyV2` secrets.
- No new MAUI dependency conflicts were introduced by the Android SDK bump; the existing NuGet-first dependency mapping remains intact.
