### PR TITLE
Fix Android offering fallback and add 16 KB guidance

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "microsoft.maui.devflow.cli": {
+      "version": "0.1.0-preview.3.26175.3",
+      "commands": [
+        "maui-devflow"
+      ]
+    }
+  }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,14 +4,15 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="DotNetEnv" Version="3.1.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.41" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.4.26201.5" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <PackageVersion Include="Xamarin.GooglePlayServices.Ads.Identifier" Version="118.2.0.3" />
     <PackageVersion Include="Xamarin.GooglePlayServices.Auth.Blockstore" Version="116.4.0.6" />

--- a/Plugin.RevenueCat/RevenueCatManager.cs
+++ b/Plugin.RevenueCat/RevenueCatManager.cs
@@ -70,7 +70,10 @@ public class RevenueCatManager : IRevenueCatManager
 		=> Request<CustomerInfo>(nameof(GetCustomerInfoAsync), () => PlatformImplementation.GetCustomerInfoAsync(force));
 	
 	public Task<Offering?> GetOfferingAsync(string offeringIdentifier)
-		=> Request<Offering>(nameof(GetOfferingAsync), () => PlatformImplementation.GetOfferingAsync(offeringIdentifier));
+	{
+		Logger.LogInformation("RevenueCatManager->{Name}: Requesting offering '{OfferingIdentifier}'.", nameof(GetOfferingAsync), offeringIdentifier);
+		return Request<Offering>(nameof(GetOfferingAsync), () => PlatformImplementation.GetOfferingAsync(offeringIdentifier));
+	}
 
 	public Task<CustomerInfo?> RestoreAsync()
 		=> Request<CustomerInfo>(nameof(RestoreAsync), PlatformImplementation.RestoreAsync);
@@ -143,7 +146,14 @@ public class RevenueCatManager : IRevenueCatManager
 	{
 		if (string.IsNullOrEmpty(json))
 		{
-			Logger.LogWarning("RevenueCatManager->{Name}: JSON response is null or empty.", name);
+			if (typeof(TObject) == typeof(Offering))
+			{
+				Logger.LogWarning("RevenueCatManager->{Name}: JSON response is null or empty. Check that the requested offering exists or that a current/default offering is configured in RevenueCat.", name);
+			}
+			else
+			{
+				Logger.LogWarning("RevenueCatManager->{Name}: JSON response is null or empty.", name);
+			}
 			return default;
 		}
 		
@@ -173,4 +183,3 @@ public class RevenueCatManager : IRevenueCatManager
 		return obj;
 	}
 }
-

--- a/README.md
+++ b/README.md
@@ -57,8 +57,32 @@ Use the `IRevenueCatManager` instance (resolved through dependency injection) to
 - `Initialize(...)` - this is called for you if you use the `UseRevenueCat()` builder method and calling it again manually has no effect
 - `Task<CustomerInfoRequest?> LoginAsync(string userId)` once you know the user identifier for your purchases, you should call this.  You should avoid calling it unnecessarily as it can cause multiple user account objects to be created if you do.  You should also try to call it as early in the lifecycle of your app as possible.
 - `Task<CustomerInfoRequest?> GetCustomerInfoAsync(bool force)` Call this to get the latest customer info.  If you use `false` for `force`, you may have a cached instance returned from the method.  Use `true` to force updating from the server.  The `CustomerInfoUpdated` event and any callback you specify in the initialization will also be called with the updated info regardless of the `force` value you set here.
-- `Task<Offering?> GetOfferingAsync(string offeringIdentifier)` Gets the offering (and its packages/products) for a given identifier.  Use this to get the information you need to display to the user when deciding on a purchase, such as the packages, prices, etc.
+- `Task<Offering?> GetOfferingAsync(string offeringIdentifier)` Gets the offering (and its packages/products) for a given identifier.  Use this to get the information you need to display to the user when deciding on a purchase, such as the packages, prices, etc.  If no exact match is found, the platform bindings will fall back to the current/default offering when one is configured.
 - `Task<CustomerInfoRequest?> RestoreAsync()` - Restores any purchases and returns the customer info which will have the entitlements relevant to the user.
 - `Task<CustomerInfoRequest?> PurchaseAsync(object? platformContext, string offeringIdentifier, string packageIdentifier)` - Initiates a purchase.  The `platformContext` should be an `Activity` (likely the current one) on Android, and is currently unused on iOS/MacCatalyst.  There's a version of this method you can call which infers the default 'current' activity of your MAUI app automatically.  You also need to pass the `offeringIdentifier` and the `packageIdentifier` the user wants to purchase (if you only have one package, pick the first one).
 - `Task<CustomerInfoRequest?> PurchaseAsync(string offeringIdentifier, string packageIdentifier)` - Same as above, but Initiates a purchase.  The `platformContext` should be an `Activity` (likely the current one) on Android, and is currently unused on iOS/MacCatalyst.  There's a version of this method you can call which infers the default 'current' activity of your MAUI app automatically.  You also need to pass the `offeringIdentifier` and the `packageIdentifier` the user wants to purchase (if you only have one package, pick the first one).
 - `Task<CustomerInfoRequest?> PurchaseAsync(string offeringIdentifier, string packageIdentifier)` - Same as above, but automatically infers the default 'current' activity of your MAUI app automatically.
+
+### Android 15 / 16 KB page-size notes
+
+This binding package does not currently ship native RevenueCat `.so` libraries on Android, so 16 KB Play Console warnings are usually caused by the consuming app's packaged native dependencies or toolchain rather than the RevenueCat wrapper itself.
+
+For Android builds, use a current .NET for Android / .NET MAUI toolchain and ensure the app package is aligned for 16 KB pages. The sample app sets:
+
+```xml
+<AndroidZipAlignment Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">16</AndroidZipAlignment>
+```
+
+If warnings persist, inspect the final APK/AAB with `zipalign -v -c -P 16 4` and check the packaged native libraries in `lib/*/*.so` to identify the actual dependency that needs updating.
+
+### Debugging the sample app with MAUI DevFlow
+
+This branch includes a local tool manifest for the new DevFlow CLI and enables the MAUI DevFlow agent in the sample app's `Debug` configuration.
+
+```bash
+dotnet tool restore
+dotnet tool run maui-devflow --help
+dotnet tool run maui-devflow update-skill
+```
+
+Build and run the sample in `Debug`, then use `maui-devflow` to inspect the app, capture screenshots, and automate UI debugging.

--- a/android/RevenueCat.Android.Binding/RevenueCat.Android.Binding.csproj
+++ b/android/RevenueCat.Android.Binding/RevenueCat.Android.Binding.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<RevenueCatSdkVersion>9.19.1</RevenueCatSdkVersion>
+		<RevenueCatSdkVersion>9.29.0</RevenueCatSdkVersion>
 		<RevenueCatSdkUrl>https://repo1.maven.org/maven2/com/revenuecat/purchases/purchases/$(RevenueCatSdkVersion)/purchases-$(RevenueCatSdkVersion).aar</RevenueCatSdkUrl>
 		<RevenueCatUISdkUrl>https://repo1.maven.org/maven2/com/revenuecat/purchases/purchases-ui/$(RevenueCatSdkVersion)/purchases-ui-$(RevenueCatSdkVersion).aar</RevenueCatUISdkUrl>
 	</PropertyGroup>

--- a/android/native/revenuecatbinding/build.gradle.kts
+++ b/android/native/revenuecatbinding/build.gradle.kts
@@ -31,11 +31,10 @@ dependencies {
     // Uncomment line below and replace {dependency.name.goes.here} with your dependency
     // implementation("{dependency.name.goes.here}")
 
-    implementation("com.revenuecat.purchases:purchases:9.19.1")
-    implementation("com.revenuecat.purchases:purchases-store-amazon:9.19.1")
+    implementation("com.revenuecat.purchases:purchases:9.29.0")
+    implementation("com.revenuecat.purchases:purchases-store-amazon:9.29.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3")
 //    implementation("com.revenuecat.purchases:purchases-ui:8.16.0")
     implementation("com.google.code.gson:gson:2.12.0")
 
 }
-

--- a/android/native/revenuecatbinding/src/main/java/com/revenuecat/revenuecatbinding/RevenueCatManager.java
+++ b/android/native/revenuecatbinding/src/main/java/com/revenuecat/revenuecatbinding/RevenueCatManager.java
@@ -107,12 +107,24 @@ public class RevenueCatManager
         Purchases.getSharedInstance().getOfferings(new ReceiveOfferingsCallback() {
             @Override
             public void onReceived(@NonNull Offerings offerings) {
-                Offering offering;
+                Offering offering = null;
 
-                if (offeringIdentifier != null)
+                if (offeringIdentifier != null && !offeringIdentifier.trim().isEmpty()) {
                     offering = offerings.get(offeringIdentifier);
-                else
+                }
+
+                if (offering == null) {
                     offering = offerings.getCurrent();
+                }
+
+                if (offering == null) {
+                    String requestedOffering = offeringIdentifier == null || offeringIdentifier.trim().isEmpty()
+                        ? "<current>"
+                        : offeringIdentifier;
+                    future.completeExceptionally(
+                        new Exception("No offering found for identifier '" + requestedOffering + "' and no current offering is configured."));
+                    return;
+                }
 
                 Map<String, Object> offeringInfo = new HashMap<>();
                 offeringInfo.put("id", offering.getIdentifier());
@@ -342,4 +354,3 @@ public class RevenueCatManager
 		return future;
 	}
 }
-

--- a/macios/native/RevenueCatBinding/RevenueCatBinding/RevenueCatBinding.swift
+++ b/macios/native/RevenueCatBinding/RevenueCatBinding/RevenueCatBinding.swift
@@ -156,7 +156,15 @@ public class RevenueCatManager : NSObject
                 
                 //callback(currentOffering.description as NSString, nil)
             } else {
-                callback(nil, nil)
+                let message = offeringId.isEmpty
+                    ? "No current offering is configured."
+                    : "No offering found for identifier '\(offeringId)' and no current offering is configured."
+                let error = NSError(
+                    domain: "RevenueCatManager",
+                    code: 404,
+                    userInfo: [NSLocalizedDescriptionKey: message]
+                )
+                callback(nil, error)
             }
         }
     }

--- a/sample/MauiProgram.cs
+++ b/sample/MauiProgram.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
+#if DEBUG
+using Microsoft.Maui.DevFlow.Agent;
+#endif
 using Plugin.RevenueCat;
 
 namespace MauiSample;
@@ -23,6 +26,7 @@ public static class MauiProgram
 		builder.Services.AddTransient<MainPage>();
 
 #if DEBUG
+		builder.AddMauiDevFlowAgent(_ => { });
 		builder.Logging.AddDebug();
 #endif
 

--- a/sample/MauiSample.csproj
+++ b/sample/MauiSample.csproj
@@ -31,6 +31,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
+		<AndroidZipAlignment Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">16</AndroidZipAlignment>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -54,6 +55,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" />
+		<PackageReference Include="Microsoft.Maui.DevFlow.Agent" Condition="'$(Configuration)' == 'Debug'" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Closes #18

## Summary
- fix Android `GetOfferingAsync()` so it mirrors iOS by falling back to the current/default offering when an exact identifier is missing
- return clearer diagnostics when no offering can be resolved instead of silently collapsing into a null-causing Android-side failure
- bump the RevenueCat Android SDK from `9.19.1` to `9.29.0`
- add the new MAUI DevFlow CLI/tool manifest and enable the DevFlow agent in the sample app's `Debug` configuration for easier repro/debugging
- document Android 15 / 16 KB page-size guidance and make the sample's Android zip alignment explicit

## Validation
- `dotnet tool restore`
- `dotnet tool run maui-devflow --version`
- `dotnet build sample/MauiSample.csproj -f net10.0-android -c Debug -v:minimal`
- `dotnet build sample/MauiSample.csproj -f net10.0-android -c Release -v:minimal`
- `zipalign -v -c -P 16 4 artifacts/bin/MauiSample/release_net10.0-android/com.troublefreepool.poolmath-Signed.apk`

## Notes
- the existing `dotnet test Tests/Tests.csproj` suite still requires RevenueCat API secrets in the environment (`AppSettings:ApiKeyV1` / `ApiKeyV2`), so it remains blocked without those credentials
- the RevenueCat Android AARs referenced by this binding do not currently ship native `.so` libraries, so the 16 KB Play Console symptom appears to be a consuming-app / .NET Android packaging concern rather than a RevenueCat binary packaging issue
