### PR TITLE
Update RevenueCat SDKs and DevFlow setup

### DIFF
--- a/.claude/skills/maui-devflow-debug/SKILL.md
+++ b/.claude/skills/maui-devflow-debug/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: maui-devflow-debug
+description: >-
+  Run build, deploy, inspect, and fix loops for .NET MAUI apps that already have
+  MAUI DevFlow integrated. USE FOR: launching MAUI apps, selecting devices or
+  emulators, waiting for or recovering agent connections, broker/port/adb
+  connectivity issues, visual tree inspection, screenshots, UI interaction,
+  Blazor WebView CDP debugging, reading DevFlow logs, and iterative app
+  debugging. DO NOT USE FOR: first-time DevFlow package setup (use
+  maui-devflow-onboard), or generic desktop automation unrelated to MAUI. INVOKES:
+  maui devflow CLI, dotnet CLI, Android adb/android tools, and Apple simctl
+  tools.
+---
+
+# DevFlow Debug
+
+Use this skill for the active debugging loop after a MAUI app has DevFlow
+packages and `builder.AddMauiDevFlowAgent()` registered.
+
+## When to Use
+
+- Build and run a MAUI app on Android, iOS, Mac Catalyst, macOS, Windows, or GTK.
+- Choose or create a simulator/emulator for a project.
+- Wait for a DevFlow agent, inspect the visual tree, tap/fill UI, or capture screenshots.
+- Recover from DevFlow connection failures after the app is integrated, including broker, port, and Android adb forwarding issues.
+- Debug Blazor Hybrid content through DevFlow WebView/CDP commands.
+- Read app logs, network captures, preferences, device info, or recordings through DevFlow.
+- Iterate on an app bug with a build -> deploy -> inspect -> fix loop.
+
+## Route Elsewhere
+
+- If DevFlow packages or `MauiProgram.cs` registration are missing, use `maui-devflow-onboard`.
+- If the failure is a generic build or SDK issue with no DevFlow angle, use normal .NET/MAUI diagnostics.
+
+## Core Loop
+
+1. Confirm the app is already integrated:
+
+   ```bash
+   grep -rl "Microsoft.Maui.DevFlow" --include="*.csproj" .
+   ```
+
+   If no project has DevFlow package references, stop and switch to `maui-devflow-onboard`.
+
+2. Pick the target framework and launch target. Do not assume `net10.0`; inspect the project first.
+
+   ```bash
+   grep -i "TargetFramework" *.csproj Directory.Build.props 2>/dev/null
+   ```
+
+3. Start or select the device/emulator. For Android and iOS, avoid reusing a simulator/emulator that is already running another app under investigation.
+
+4. Launch the app and keep the launch process alive when required.
+
+   - iOS, Android, and Mac Catalyst `dotnet build -t:Run` usually block for the app lifetime.
+   - GTK `dotnet run` blocks for the app lifetime.
+   - macOS AppKit builds can exit after compiling; launch the `.app` separately.
+
+5. Wait for the DevFlow agent before inspecting UI:
+
+   ```bash
+   maui devflow wait
+   maui devflow ui tree --depth 3 --fields "id,type,text,automationId"
+   ```
+
+   If `wait`, `list`, or `ui tree` cannot connect after the app is running, load `references/connectivity.md` and recover the broker/agent connection before continuing.
+
+6. Inspect, interact, capture evidence, then edit the app and repeat from launch.
+
+## Critical Anti-patterns
+
+- Do not treat an empty `maui devflow list` as proof the project is not integrated. `list` is runtime state; project files are source of truth.
+- Do not use arbitrary sleeps after launch. Use `maui devflow wait` to gate on the actual agent connection.
+- Do not kill an async `dotnet build -t:Run` or `dotnet run` shell while you still need the app; that often kills the app.
+- Do not reuse a busy simulator/emulator when multiple MAUI apps or agents may be running.
+- Do not debug Blazor WebView DOM issues through the native visual tree alone; use the WebView/CDP commands.
+
+## Stop Signals
+
+- Stop and switch to `maui-devflow-onboard` when package references or `AddMauiDevFlowAgent()` are absent.
+- Stop and ask which project, device, or agent to target when multiple candidates match.
+- Stop rebuilding after two identical failures until you inspect the first meaningful build/runtime error.
+- Stop using screenshots for exact property values; query the visual tree or properties instead.
+
+## Reference Map
+
+Load these only when needed:
+
+- `references/setup.md` - detailed integration, package, entitlement, and update notes.
+- `references/connectivity.md` - broker, agent, port, Android forwarding, and "no agents connected" recovery.
+- `references/android.md` - Android SDK, emulator, adb, build, deploy, and port forwarding details.
+- `references/ios-and-mac.md` - iOS simulator, Mac Catalyst, permissions, entitlements, and Apple tooling.
+- `references/macos.md` - macOS AppKit project shape, launch model, and troubleshooting.
+- `references/linux.md` - GTK/Linux launch, packages, and WebKitGTK notes.
+- `references/batch.md` - batching multiple DevFlow UI/WebView operations.
+- `references/troubleshooting.md` - build, connection, CDP, and platform-specific failure recovery.

--- a/.claude/skills/maui-devflow-debug/references/android.md
+++ b/.claude/skills/maui-devflow-debug/references/android.md
@@ -1,0 +1,213 @@
+# Android Reference
+
+## Table of Contents
+- [Emulator Management](#emulator-management)
+- [Building and Deploying](#building-and-deploying)
+- [Android CLI Tool](#android-cli-tool)
+- [ADB Reference](#adb-reference)
+- [SDK Management](#sdk-management)
+- [Troubleshooting](#troubleshooting)
+
+## Emulator Management
+
+### Avoiding multi-project conflicts
+
+When multiple projects (or AI agents) may deploy to Android emulators simultaneously,
+each project should use its own dedicated AVD. Two apps deployed to the same emulator
+will coexist (unlike iOS), but `adb reverse`/`adb forward` port forwarding is per-device
+and can cause confusion when multiple emulators are running.
+
+**Before creating or starting an emulator, check what's already in use:**
+```bash
+maui devflow list                             # shows agents with platform + port
+adb devices                                   # shows connected emulators
+```
+
+If an emulator is already running another project's agent, create a new AVD:
+```bash
+android avd create --name "ProjectName-Pixel8" \
+  --sdk "system-images;android-35;google_apis;arm64-v8a" --device pixel_8
+android avd start --name "ProjectName-Pixel8"
+```
+
+**When multiple emulators are running**, use `-s <serial>` to target a specific one:
+```bash
+adb -s emulator-5554 reverse tcp:19223 tcp:19223   # first emulator
+adb -s emulator-5556 reverse tcp:19223 tcp:19223   # second emulator
+```
+
+**Naming convention:** Use `<ProjectName>-<DeviceType>` (e.g. `TodoApp-Pixel8`) so it's
+clear which AVD belongs to which project.
+
+### List and start AVDs
+```bash
+android avd list                              # list available AVDs
+android avd start --name <avd-name>           # start emulator
+```
+
+### Create AVD
+```bash
+# List available targets and device profiles
+android avd targets                           # system images
+android avd devices                           # device profiles (pixel, etc.)
+
+android avd create --name "Pixel8API35" \
+  --sdk "system-images;android-35;google_apis;arm64-v8a" \
+  --device pixel_8
+```
+
+### Delete AVD
+```bash
+android avd delete --name <avd-name>
+```
+
+### Verify emulator is running
+```bash
+adb devices                                   # should show "emulator-5554 device"
+android device list                           # formatted list
+```
+
+## Building and Deploying
+
+```bash
+# Build and deploy to running emulator
+dotnet build -f net10.0-android -t:Run
+
+# Build only (no deploy)
+dotnet build -f net10.0-android
+```
+
+**Critical: Port forwarding after deploy** — the Android emulator runs in its own network.
+Forward the broker port and the agent port:
+```bash
+adb reverse tcp:19223 tcp:19223              # Broker (lets agent register)
+adb forward tcp:<port> tcp:<port>            # Agent (lets CLI reach agent)
+```
+
+The broker reverse is needed so the agent inside the emulator can connect to the host's
+broker daemon. The agent forward uses the port shown in `maui devflow list` after the agent
+registers (range 10223–10899).
+
+If the broker isn't available (fallback mode), forward the port from `.mauidevflow` instead:
+```bash
+adb forward tcp:9223 tcp:9223                # Fallback: direct agent port
+```
+
+Then verify: `maui devflow ui status` and `maui devflow webview status`.
+
+### Install APK manually
+```bash
+adb install -r path/to/app.apk               # install/reinstall
+android device install --package path/to/app.apk
+```
+
+## Android CLI Tool
+
+The `android` command (from `androidsdk.tool` NuGet) wraps SDK tools.
+
+### SDK management
+```
+android sdk list                              # all packages
+android sdk list --installed                  # installed only
+android sdk list --available                  # available for install
+android sdk install --package "platforms;android-35"
+android sdk install --package "system-images;android-35;google_apis;arm64-v8a"
+android sdk install --package "emulator"
+android sdk uninstall --package <package-name>
+android sdk info                              # SDK location, tools versions
+android sdk accept-licenses                   # accept all SDK licenses
+android sdk download                          # download cmdline-tools
+```
+
+### AVD management
+```
+android avd list                              # available AVDs
+android avd targets                           # available system images
+android avd devices                           # available device profiles
+android avd create --name <name> --sdk <system-image> --device <device>
+android avd delete --name <name>
+android avd start --name <name>
+```
+
+### Device/emulator operations
+```
+android device list                           # connected devices/emulators
+android device info [--device <serial>]       # device properties
+android device install --package <apk>        # install APK
+android device uninstall --package <pkg-id>   # uninstall by package name
+```
+
+### JDK management
+```
+android jdk list                              # available JDKs
+android jdk info                              # current JDK info
+```
+
+## ADB Reference
+
+### Device/emulator basics
+```bash
+adb devices                                   # list connected devices
+adb -s <serial> shell                         # shell into specific device
+adb shell pm list packages | grep <name>      # find installed packages
+adb shell am start -n <pkg>/<activity>        # launch activity
+adb shell am force-stop <pkg>                 # kill app
+```
+
+### Port forwarding (critical for MAUI DevFlow)
+```bash
+adb reverse tcp:19223 tcp:19223              # Broker (agent → host)
+adb forward tcp:<port> tcp:<port>            # Agent (CLI → emulator, get port from `maui devflow list`)
+adb reverse --list                            # verify forwarding
+adb forward --list                            # verify forwarding
+adb reverse --remove-all                      # clean up reverse
+adb forward --remove-all                      # clean up forward
+```
+
+### File operations
+```bash
+adb push local/file /sdcard/path              # push file to device
+adb pull /sdcard/path local/file              # pull file from device
+```
+
+### Logs
+```bash
+adb logcat -s "DOTNET" --format brief         # .NET runtime logs
+adb logcat -s "MauiDevFlow"                   # agent logs
+adb logcat --pid=$(adb shell pidof <pkg>)     # app-specific logs
+adb logcat -c                                 # clear log buffer
+```
+
+### Screenshots and screen recording
+```bash
+adb shell screencap /sdcard/screen.png && adb pull /sdcard/screen.png
+adb shell screenrecord /sdcard/video.mp4      # Ctrl+C to stop
+```
+
+## SDK Management
+
+### Typical setup for MAUI Android development
+```bash
+android sdk accept-licenses
+android sdk install --package "platforms;android-35"
+android sdk install --package "build-tools;35.0.0"
+android sdk install --package "system-images;android-35;google_apis;arm64-v8a"
+android sdk install --package "emulator"
+android sdk install --package "platform-tools"
+```
+
+### Environment variables
+```bash
+export ANDROID_HOME=$HOME/Library/Android/sdk
+export ANDROID_SDK_ROOT=$ANDROID_HOME
+export PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator
+```
+
+## Troubleshooting
+
+- **`adb devices` shows "unauthorized"**: Accept the USB debugging prompt on the device/emulator.
+- **Agent not connecting on emulator**: Forgot `adb reverse tcp:19223 tcp:19223` for the broker. Run port forwarding, then check `maui devflow list`.
+- **Emulator won't start**: Check available system images with `android avd targets`. May need
+  to install with `android sdk install --package "system-images;..."`.
+- **Build error "No Android devices found"**: Ensure emulator is booted (`adb devices`).
+- **Slow emulator**: Use hardware acceleration. Prefer `arm64-v8a` images on Apple Silicon Macs.

--- a/.claude/skills/maui-devflow-debug/references/batch.md
+++ b/.claude/skills/maui-devflow-debug/references/batch.md
@@ -1,0 +1,50 @@
+# Batch Command Reference
+
+Execute multiple MAUI/cdp commands in a single CLI invocation via stdin. Outputs JSONL
+responses (one JSON object per line) to stdout — ideal for AI agents and scripting.
+
+## Usage
+
+```bash
+# Pipe multiple commands (semicolons or newlines as separators)
+echo "MAUI fill textUsername user; MAUI fill textPassword pwd123; MAUI tap buttonLogin" | maui devflow batch
+
+# Multi-line input
+printf "MAUI status\nMAUI tree\nMAUI screenshot --output screen.png" | maui devflow batch
+
+# With options
+echo "MAUI status; MAUI tree" | maui devflow batch --delay 500 --continue-on-error --agent-port 10224
+
+# Human-readable output instead of JSONL
+echo "MAUI status; MAUI tree" | maui devflow batch --human
+```
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--delay <ms>` | 250 | Delay between commands (lets UI settle) |
+| `--continue-on-error` | false | Continue after a command fails (default: stop) |
+| `--human` | false | Human-readable output instead of JSONL |
+
+## JSONL Response Format
+
+One JSON object per command, streamed as each completes:
+```json
+{"command":"MAUI fill textUsername user","exit_code":0,"output":"Filled: textUsername"}
+{"command":"MAUI tap buttonLogin","exit_code":1,"output":"Error: Element not found: buttonLogin"}
+```
+
+## Interactive Streaming
+
+The batch command processes stdin line-by-line, so a caller can read each JSONL response
+before sending the next command. This enables reactive workflows where the AI agent inspects
+results and decides the next action.
+
+## Input Rules
+
+- Lines starting with `#` are comments (skipped)
+- Empty lines are skipped
+- Semicolons separate multiple commands on one line
+- Quoted strings are preserved: `MAUI fill myEntry "hello world"`
+- Only `MAUI` and `cdp` commands are allowed (broker/list/etc. are rejected)

--- a/.claude/skills/maui-devflow-debug/references/connectivity.md
+++ b/.claude/skills/maui-devflow-debug/references/connectivity.md
@@ -1,0 +1,114 @@
+# Connectivity Recovery
+
+Use this when a project already has DevFlow package references and `builder.AddMauiDevFlowAgent()` registered, but the `maui` CLI cannot reach a running app.
+
+## Quick workflow
+
+1. Run the built-in diagnostic:
+
+   ```bash
+   maui devflow diagnose
+   ```
+
+   Use the result to separate broker startup, missing project integration, no running app, and target-device networking issues.
+
+2. Verify integration before chasing ports:
+
+   ```bash
+   grep -R --include="*.csproj" "Microsoft.Maui.DevFlow.Agent" .
+   grep -R "AddMauiDevFlowAgent" .
+   ```
+
+   If package references or `AddMauiDevFlowAgent()` are missing, stop and switch to `maui-devflow-onboard`.
+
+3. Check broker health:
+
+   ```bash
+   maui devflow broker status
+   maui devflow broker start
+   ```
+
+4. List and wait for agents:
+
+   ```bash
+   maui devflow list
+   maui devflow wait
+   maui devflow ui tree --depth 1
+   ```
+
+   A successful `ui tree` means connectivity is fixed; continue the main debug loop.
+
+## Platform notes
+
+### Android emulator
+
+Android emulators run in a separate network namespace. Broker registration and CLI-to-agent traffic need opposite forwarding directions:
+
+```bash
+maui devflow list                 # note the assigned agent port
+adb reverse tcp:19223 tcp:19223   # app in emulator -> host broker
+adb forward tcp:<port> tcp:<port> # host CLI -> app agent
+adb reverse --list
+adb forward --list
+```
+
+If no broker is available and the app uses a direct `.mauidevflow` port, forward that port instead:
+
+```bash
+adb forward tcp:9223 tcp:9223
+```
+
+### iOS simulator
+
+No forwarding is normally needed because simulators share host networking:
+
+```bash
+xcrun simctl list devices booted
+```
+
+### Mac Catalyst and macOS
+
+Mac Catalyst needs Debug entitlements that allow the agent and CDP servers to bind ports:
+
+```xml
+<key>com.apple.security.network.server</key>
+<true/>
+```
+
+macOS AppKit and Mac Catalyst otherwise use direct localhost access. Check for explicit port conflicts only after confirming broker discovery:
+
+```bash
+lsof -i :9223
+```
+
+### Windows and Linux/GTK
+
+These use direct localhost access. On Linux, verify the app process started:
+
+```bash
+pgrep -f "YourApp"
+```
+
+## Common symptoms
+
+| Symptom | Fix |
+|---------|-----|
+| `maui devflow list` shows no agents | Verify app is running in Debug, package references exist, and `AddMauiDevFlowAgent()` executes |
+| Android agent never registers | Run `adb reverse tcp:19223 tcp:19223` for broker registration |
+| Android connection refused after registration | Run `adb forward tcp:<port> tcp:<port>` using the port from `maui devflow list` |
+| Broker unavailable | `maui devflow broker start`; retry the command |
+| Port already in use | Identify the owner with `lsof -i :<port>` before killing a PID |
+| Multiple agents connected | Ask which app/device/agent port to target; use `--agent-port` |
+
+## Stop signals
+
+- Stop and switch to `maui-devflow-onboard` if package references or `AddMauiDevFlowAgent()` are missing.
+- Stop connectivity recovery once `maui devflow wait` succeeds and `maui devflow ui tree --depth 1` returns a tree.
+- Stop and ask which target to use if multiple connected agents or devices match the app.
+- Stop after confirming a generic build/deploy failure; the app must launch before broker connectivity can work.
+
+## Anti-patterns
+
+- Do not treat an empty `maui devflow list` as proof the project is not integrated. It only means no runtime agent is connected.
+- Do not use `adb reverse` for the agent HTTP port when the host CLI must connect into the emulator. Use `adb forward tcp:<port> tcp:<port>` for that direction.
+- Do not kill random processes by name. Identify the owning PID first.

--- a/.claude/skills/maui-devflow-debug/references/ios-and-mac.md
+++ b/.claude/skills/maui-devflow-debug/references/ios-and-mac.md
@@ -1,0 +1,324 @@
+# iOS & Mac Catalyst Reference
+
+## Table of Contents
+- [Simulator Management](#simulator-management)
+- [Building and Deploying](#building-and-deploying)
+- [Apple CLI Tool](#apple-cli-tool)
+- [xcrun simctl Reference](#xcrun-simctl-reference)
+- [Troubleshooting](#troubleshooting)
+
+## Simulator Management
+
+### Avoiding multi-project conflicts
+
+When multiple projects (or AI agents) may deploy to iOS simulators simultaneously, each
+project should use its own dedicated simulator. Two apps deployed to the same simulator
+will replace each other — only the last-deployed app survives.
+
+**Before creating or booting a simulator, check what's already in use:**
+```bash
+maui devflow list                             # shows agents with platform + port
+xcrun simctl list devices booted              # shows all booted simulators
+```
+
+If a booted simulator is already running another project's agent, create a new one:
+```bash
+xcrun simctl create "ProjectName-iPhone17Pro" "iPhone 17 Pro" "iOS 26.2"
+# Use the returned UDID in your build command
+```
+
+**Naming convention:** Use `<ProjectName>-<DeviceType>` (e.g. `TodoApp-iPhone17Pro`) so
+it's clear which simulator belongs to which project.
+
+### List simulators
+```bash
+xcrun simctl list devices                     # all devices by runtime
+xcrun simctl list devices booted              # only booted
+xcrun simctl list devices available            # only available
+apple simulator list                          # formatted table
+apple simulator list --booted                 # booted only
+```
+
+### Create simulator
+```bash
+# List available device types and runtimes first
+xcrun simctl list devicetypes                 # e.g. "iPhone 16 Pro"
+xcrun simctl list runtimes                    # e.g. "iOS 18.2"
+
+xcrun simctl create "My iPhone" "iPhone 16 Pro" "iOS 18.2"
+apple simulator create "My iPhone" --device-type "iPhone 16 Pro" --runtime "iOS 18.2"
+```
+
+### Boot / shutdown
+```bash
+xcrun simctl boot <UDID>
+xcrun simctl shutdown <UDID>
+apple simulator boot <UDID>
+apple simulator shutdown <UDID>
+```
+
+### Install and launch app
+```bash
+xcrun simctl install booted /path/to/App.app
+xcrun simctl launch booted com.company.appid
+```
+
+### Screenshots (iOS Simulator)
+```bash
+xcrun simctl io booted screenshot output.png
+apple simulator screenshot <UDID> --output output.png
+```
+
+### Screenshots (Mac Catalyst)
+
+**Use `maui devflow ui screenshot`** for Mac Catalyst apps — it captures the UI in-process
+and does NOT require the app to be in the foreground. Never use `osascript` to bring the window
+to the front or `screencapture` for Mac Catalyst screenshots; they are unnecessary and unreliable.
+
+```bash
+maui devflow ui screenshot --output screen.png
+```
+
+### Delete / erase
+```bash
+xcrun simctl erase <UDID>                     # factory reset
+xcrun simctl delete <UDID>                    # permanently remove
+xcrun simctl delete unavailable               # clean up old sims
+```
+
+## Building and Deploying
+
+### Mac Catalyst
+
+**⚠️ Entitlements required:** Mac Catalyst apps are sandboxed by default and need the
+`com.apple.security.network.server` entitlement for MAUI DevFlow's in-app HTTP server.
+Without it, the agent fails to bind its port and the app may crash silently.
+
+**Quick fix (disable sandbox for Debug):** Create `Platforms/MacCatalyst/Entitlements.Debug.plist`:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+  </dict>
+</plist>
+```
+
+Then reference it in `.csproj` for Debug only:
+```xml
+<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))
+    == 'maccatalyst' and '$(Configuration)' == 'Debug'">
+  <CodeSignEntitlements>Platforms/MacCatalyst/Entitlements.Debug.plist</CodeSignEntitlements>
+</PropertyGroup>
+```
+
+If sandbox must stay enabled (e.g. testing App Store builds), add `network.server` explicitly.
+See [setup.md Step 5](setup.md#5-mac-catalyst-entitlements) for the full sandbox-enabled plist.
+
+```bash
+dotnet build -f net10.0-maccatalyst                          # build only
+dotnet build -f net10.0-maccatalyst -t:Run                   # build + run
+open path/to/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/AppName.app  # run existing
+```
+
+### iOS Simulator
+```bash
+# Find UDID of booted simulator
+UDID=$(xcrun simctl list devices booted -j | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for r in d['devices'].values():
+  for dev in r:
+    if dev['state']=='Booted': print(dev['udid']); break
+" 2>/dev/null | head -1)
+
+# Build and deploy
+dotnet build -f net10.0-ios -t:Run -p:_DeviceName=:v2:udid=$UDID
+```
+
+The `-t:Run` target keeps the process alive while the app runs — it **blocks until the app exits**.
+Always run in an async/background shell, then poll `maui devflow ui status` to detect when the
+app is ready. Do NOT wait for the process to finish.
+
+### Determining the correct TFM
+Check the project file for `<TargetFrameworks>`:
+```bash
+grep -i TargetFramework *.csproj
+```
+Common values: `net9.0-ios`, `net9.0-maccatalyst`, `net10.0-ios`, `net10.0-maccatalyst`.
+
+## Apple CLI Tool
+
+The `apple` command (from `appledev.tools` NuGet) provides higher-level wrappers.
+
+### Simulator commands
+```
+apple simulator list [--booted|--available|--unavailable|--name "..."]
+apple simulator create <name> --device-type "..." [--runtime "..."]
+apple simulator boot <target>
+apple simulator shutdown <target>
+apple simulator erase <target>
+apple simulator delete <target>
+apple simulator screenshot <target> [--output path.png]
+apple simulator app install <target> <app-path>
+apple simulator app launch <target> <bundle-id>
+apple simulator app uninstall <target> <bundle-id>
+apple simulator open [<target>]
+apple simulator open-url <target> <url>
+apple simulator logs <target> [--filter "..."]
+apple simulator push <target> <bundle-id> [--payload "..."]
+apple simulator location set <target> --lat <lat> --lon <lon>
+apple simulator privacy grant <target> <service> <bundle-id>
+```
+
+### Device commands
+```
+apple device list
+apple xcode list                                # installed Xcode versions
+```
+
+## xcrun simctl Reference
+
+Key subcommands beyond the basics:
+
+| Command | Use |
+|---------|-----|
+| `simctl addmedia <UDID> file.jpg` | Add photos/videos to sim |
+| `simctl openurl <UDID> "url"` | Open URL / deep link |
+| `simctl push <UDID> bundle payload.json` | Simulate push notification |
+| `simctl privacy <UDID> grant location bundle` | Grant permissions |
+| `simctl location <UDID> set 37.33,-122.03` | Set GPS location |
+| `simctl pbcopy <UDID>` | Copy stdin to clipboard |
+| `simctl pbpaste <UDID>` | Read clipboard |
+| `simctl get_app_container <UDID> bundle` | App container path |
+| `simctl listapps <UDID>` | Installed apps |
+
+## Troubleshooting
+
+- **Mac Catalyst blank/white screen after crash**: macOS shows a "reopen windows" dialog after
+  a crash, blocking the app from rendering. All MAUI elements appear as `[hidden] [disabled]`
+  with `-1x-1` sizes. Fix: clear saved state before launch:
+  ```bash
+  rm -rf ~/Library/Saved\ Application\ State/<bundle-id>.savedState
+  ```
+  If the "Reopen windows?" dialog is already on screen, ask the user to dismiss it manually,
+  then relaunch. Do not use AppleScript here by default — it steals focus from the user's
+  desktop session.
+- **"Unable to lookup in current state: Shutdown"**: Simulator not booted. Run `xcrun simctl boot <UDID>`.
+- **Build error NETSDK1005 "Assets file doesn't have a target"**: Wrong TFM. Check
+  `<TargetFrameworks>` in .csproj and use matching version (e.g. `net10.0-ios` not `net9.0-ios`).
+- **Agent not connecting after deploy**: The app may still be launching. Poll
+  `maui devflow ui status` every few seconds. If it hasn't connected after ~60-90s, read the
+  async shell output from `dotnet build -t:Run` for build/launch errors.
+- **Mac Catalyst app name vs binary name**: The `.app` bundle name may differ from the project
+  name (e.g. `MauiTodo.app` vs `SampleMauiApp`). Check the `ApplicationTitle` in .csproj.
+  Find the bundle: `find bin/Debug/net10.0-maccatalyst -name "*.app" -maxdepth 3`
+
+## Permission & Dialog Handling
+
+### Pre-grant permissions (prevents dialogs from appearing)
+```bash
+# Grant specific permission before the app requests it
+xcrun simctl privacy <UDID> grant location com.company.appid
+xcrun simctl privacy <UDID> grant camera com.company.appid
+xcrun simctl privacy <UDID> grant photos com.company.appid
+xcrun simctl privacy <UDID> grant contacts com.company.appid
+xcrun simctl privacy <UDID> grant microphone com.company.appid
+
+# Grant all permissions at once
+xcrun simctl privacy <UDID> grant all com.company.appid
+
+# Revoke (deny) a permission
+xcrun simctl privacy <UDID> revoke location com.company.appid
+
+# Reset (next request will show dialog again)
+xcrun simctl privacy <UDID> reset all com.company.appid
+
+# Via apple CLI
+apple simulator privacy grant <UDID> location com.company.appid
+```
+
+Available services: `all`, `calendar`, `contacts`, `contacts-limited`, `location`, `location-always`, `photos`, `photos-add`, `media-library`, `microphone`, `motion`, `reminders`, `siri`.
+
+### Using MAUI DevFlow Driver for permissions
+```csharp
+var driver = new iOSSimulatorAppDriver();
+driver.DeviceUdid = "<UDID>";
+driver.BundleId = "com.company.appid";
+
+// Pre-grant before running the app
+await driver.GrantPermissionAsync(PermissionService.Location);
+await driver.GrantPermissionAsync(PermissionService.Camera);
+
+// Reset to test the dialog flow
+await driver.ResetPermissionAsync(PermissionService.Location);
+```
+
+### Detecting and dismissing alerts (accessibility tree + HID tap)
+When a dialog appears unexpectedly (permission prompt, app alert, action sheet), the driver can
+detect it via the iOS accessibility tree and tap a button to dismiss it:
+
+```csharp
+// Check if an alert is currently showing
+var alert = await driver.DetectAlertAsync();
+if (alert is not null)
+{
+    Console.WriteLine($"Alert: {alert.Title}");
+    foreach (var btn in alert.Buttons)
+        Console.WriteLine($"  Button: {btn.Label} at ({btn.CenterX},{btn.CenterY})");
+}
+
+// Dismiss by tapping the first "accept" button (Allow, OK, etc.)
+await driver.DismissAlertAsync();
+
+// Dismiss by tapping a specific button
+await driver.DismissAlertAsync("Don't Allow");
+
+// Convenience: detect + dismiss if present, no-op if not
+await driver.HandleAlertIfPresentAsync();
+```
+
+### Example workflow: permission dialog handling
+```
+1. App requests location → system shows "Allow location?" dialog
+2. Agent detects dialog via DetectAlertAsync()
+3. Agent sees buttons: ["Allow While Using App", "Allow Once", "Don't Allow"]
+4. Agent taps "Allow While Using App" via DismissAlertAsync("Allow While Using App")
+5. App receives permission grant, continues normal flow
+```
+
+### Dialog test page in SampleMauiApp
+The SampleMauiApp includes a **Dialogs** tab with buttons that trigger:
+- **Permission dialogs**: Location, Camera, Photos, Contacts, Microphone, Notifications
+- **App alerts**: OK-only, OK/Cancel, custom buttons (Delete/Keep)
+- **Action sheets**: Multiple options with cancel/destructive
+- **Prompt dialogs**: Text input with OK/Cancel
+
+Use these to test and validate dialog detection and dismissal workflows.
+
+## Dark Mode Testing
+
+### Toggle dark mode
+```bash
+# Preferred when available: use an in-app theme toggle so the host desktop is unaffected.
+#
+# iOS Simulator (safe: affects the simulator only)
+xcrun simctl ui <UDID> appearance dark
+xcrun simctl ui <UDID> appearance light
+```
+
+For **Mac Catalyst**, changing system appearance affects the user's entire macOS desktop. Only do
+that with explicit user approval; otherwise prefer app-level theme controls and verify via
+`maui devflow ui property` / WebView inspection.
+
+### Verify dark mode via inspection
+Use `maui devflow` to verify colors without relying on screenshots:
+```bash
+maui devflow ui property <elementId> BackgroundColor   # check MAUI element colors
+maui devflow webview Runtime evaluate "window.matchMedia('(prefers-color-scheme: dark)').matches"  # Blazor
+```

--- a/.claude/skills/maui-devflow-debug/references/linux.md
+++ b/.claude/skills/maui-devflow-debug/references/linux.md
@@ -1,0 +1,172 @@
+# Linux / GTK Platform Guide
+
+Platform-specific setup and usage for .NET MAUI apps running on Linux via Maui.Gtk (GTK4).
+
+## Overview
+
+Maui.Gtk apps target `net10.0` (not a platform-specific TFM like `net10.0-ios`) and use
+GTK4 via GirCore bindings. MAUI DevFlow provides dedicated Linux packages that work with
+this architecture.
+
+## NuGet Packages
+
+| Package | Purpose |
+|---------|---------|
+| `Microsoft.Maui.DevFlow.Agent.Gtk` | In-app agent (visual tree, screenshots, tapping, logging) |
+| `Microsoft.Maui.DevFlow.Blazor.Gtk` | CDP bridge for WebKitGTK BlazorWebView |
+
+These replace `Microsoft.Maui.DevFlow.Agent` and `Microsoft.Maui.DevFlow.Blazor` which target
+standard MAUI platforms (iOS, Android, macCatalyst, Windows).
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.Maui.DevFlow.Agent.Gtk" Version="*" />
+  <!-- Blazor Hybrid apps also need: -->
+  <PackageReference Include="Microsoft.Maui.DevFlow.Blazor.Gtk" Version="*" />
+</ItemGroup>
+```
+
+## Registration
+
+### MauiProgram.cs
+
+```csharp
+using Microsoft.Maui.DevFlow.Agent.Gtk;
+using Microsoft.Maui.DevFlow.Blazor.Gtk;  // Blazor Hybrid only
+
+var builder = MauiApp.CreateBuilder();
+// ... your existing setup ...
+
+#if DEBUG
+builder.AddMauiDevFlowAgent();
+builder.AddMauiBlazorDevFlowTools(); // Blazor Hybrid only
+#endif
+```
+
+### Application Startup
+
+The agent must be started after the MAUI Application is available. In your GTK app
+startup (e.g., `GtkMauiApplication.OnActivate` or equivalent):
+
+```csharp
+#if DEBUG
+app.StartDevFlowAgent();
+
+// For Blazor Hybrid, wire CDP to the agent:
+var blazorService = app.Handler?.MauiContext?.Services
+    .GetService<GtkBlazorWebViewDebugService>();
+blazorService?.WireBlazorCdpToAgent();
+#endif
+```
+
+## Building and Running
+
+Linux/GTK apps use `dotnet run` (not `dotnet build -t:Run` which is MAUI-specific):
+
+```bash
+# Build and run (in background/async shell)
+dotnet run --project <path-to-gtk-project>
+
+# Build only
+dotnet build <path-to-gtk-project>
+```
+
+Build times are typically fast (~5-10s) since there's no device deployment step.
+
+## Network Setup
+
+**No special setup needed.** Linux apps run directly on localhost — the CLI connects
+directly to `http://localhost:<port>`. No port forwarding (unlike Android) or entitlements
+(unlike Mac Catalyst) required.
+
+## Key Simulation
+
+The `LinuxAppDriver` automatically detects the display server and uses the appropriate
+**driver-mediated** key simulation backend. This is an implementation detail for Linux
+automation support, **not** a recommendation for an AI agent to invoke these tools directly
+from the shell. Prefer `maui devflow ui fill`, `maui devflow ui tap`, and `maui devflow batch`
+for normal interaction.
+
+- **X11 sessions**: Uses `xdotool` (human-readable key names, no daemon needed)
+- **Wayland sessions**: Uses `ydotool` (Linux input event keycodes, requires `ydotoold` daemon)
+
+Detection uses `XDG_SESSION_TYPE` and `WAYLAND_DISPLAY` environment variables. If the
+preferred tool isn't installed, it falls back to whichever is available.
+
+### Installing xdotool (X11)
+
+```bash
+sudo apt install xdotool       # Debian/Ubuntu
+sudo dnf install xdotool       # Fedora
+```
+
+### Installing ydotool (Wayland)
+
+```bash
+sudo apt install ydotool       # Debian/Ubuntu
+sudo dnf install ydotool       # Fedora
+```
+
+**Required setup for ydotool** (to run without root):
+
+```bash
+# Add your user to the input group for /dev/uinput access
+sudo usermod -aG input $USER
+
+# Create udev rule for persistent permissions
+echo 'KERNEL=="uinput", GROUP="input", MODE="0660"' | sudo tee /etc/udev/rules.d/99-uinput.rules
+sudo udevadm control --reload-rules && sudo udevadm trigger
+
+# Log out and back in, then start the daemon
+ydotoold &
+```
+
+Key simulation is used by the driver for alert dismissal and keyboard input.
+Only the driver backend should reach for `xdotool` or `ydotool`.
+
+## Platform Differences
+
+| Feature | Standard MAUI | Linux/GTK |
+|---------|--------------|-----------|
+| NuGet packages | `Agent`, `Blazor` | `Agent.Gtk`, `Blazor.Gtk` |
+| TFM | `net10.0-<platform>` | `net10.0` |
+| Build command | `dotnet build -f $TFM -t:Run` | `dotnet run --project <path>` |
+| Agent startup | Automatic (lifecycle hook) | Manual (`app.StartDevFlowAgent()`) |
+| Network | Varies by platform | Direct localhost |
+| Screenshots | `VisualDiagnostics` | GTK `WidgetPaintable` → `Texture.SaveToPng()` |
+| Native tap | Platform gesture system | `Gtk.Widget.Activate()` |
+| Key simulation | Driver-mediated backend | `xdotool` (X11) / `ydotool` (Wayland) |
+| Screen recording | Platform-specific | `ffmpeg` with `x11grab` (X11) / `pipewire` (Wayland) |
+| Blazor WebView | WKWebView / WebView2 / Chrome | WebKitGTK 6.0 |
+
+## Troubleshooting
+
+### Agent Not Starting
+
+1. Ensure `app.StartDevFlowAgent()` is called after the app is activated
+2. Check that `Application.Current` is available when `StartDevFlowAgent()` runs
+3. Verify the port isn't in use: `lsof -i :<port>` or `ss -tlnp | grep <port>`
+
+### xdotool / ydotool Not Working
+
+- On Wayland, `xdotool` does not work — install `ydotool` and start `ydotoold`
+- On X11, `xdotool` is preferred over `ydotool` (simpler, no daemon)
+- Prefer DevFlow commands over direct key injection wherever possible
+- If `ydotool` fails silently, check that `ydotoold` daemon is running: `pgrep -x ydotoold`
+- If `ydotool` gives permission errors, ensure your user is in the `input` group and `/dev/uinput` is group-writable
+- Ensure the app window has focus for key events
+- Check `XDG_SESSION_TYPE` to verify which display server is active: `echo $XDG_SESSION_TYPE`
+
+### Screen Recording on Wayland
+
+- Wayland screen recording uses `ffmpeg -f pipewire` instead of `x11grab`
+- Requires PipeWire to be installed and running (standard on modern Wayland desktops)
+- Check ffmpeg PipeWire support: `ffmpeg -devices | grep pipewire`
+- If PipeWire is not available, you can force X11 with `GDK_BACKEND=x11` and use `x11grab`
+- The first recording on Wayland may trigger a system permission dialog for screen sharing
+
+### WebKitGTK CDP Issues
+
+- WebKitGTK uses `EvaluateJavascriptAsync` for JS evaluation
+- The same two-eval CDP pattern (send + poll) applies as other platforms
+- Check that `chobitsu.js` is properly loaded in the WebView

--- a/.claude/skills/maui-devflow-debug/references/macos.md
+++ b/.claude/skills/maui-devflow-debug/references/macos.md
@@ -1,0 +1,205 @@
+# macOS (AppKit) Platform Guide
+
+Platform-specific setup and usage for .NET MAUI apps running on macOS via Platform.Maui.MacOS (AppKit).
+
+## Table of Contents
+- [Overview](#overview)
+- [Project Structure](#project-structure)
+- [NuGet Packages](#nuget-packages)
+- [Registration](#registration)
+- [Building and Running](#building-and-running)
+- [Blazor Hybrid](#blazor-hybrid)
+- [Platform Differences](#platform-differences)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+macOS (AppKit) apps use the community `Platform.Maui.MacOS` packages to run MAUI on native
+AppKit (not Mac Catalyst). The TFM is `net10.0-macos`. Like Linux/GTK, macOS apps typically
+use a **separate app head project** rather than adding `-macos` to the standard MAUI project's
+TargetFrameworks.
+
+Detect macOS projects:
+```bash
+grep -i 'Platform\.Maui\.MacOS\|net.*-macos' *.csproj Directory.Build.props 2>/dev/null
+```
+
+## Project Structure
+
+macOS apps use a separate app head project (similar to Linux/GTK):
+
+```
+src/
+├── MyApp/                    # Standard MAUI project (iOS, Android, Mac Catalyst, Windows)
+├── MyApp.MacOS/              # macOS AppKit app head
+│   ├── Program.cs            # Entry point: MacOSMauiApplication
+│   ├── MauiProgram.cs        # macOS-specific builder (UseMauiAppMacOS, AddMacOSEssentials)
+│   └── MyApp.MacOS.csproj    # References Platform.Maui.MacOS packages
+```
+
+Shared source files (pages, view models, services) are typically linked from the main project.
+
+## NuGet Packages
+
+The app project needs the Platform.Maui.MacOS packages plus the standard MAUI DevFlow packages:
+
+```xml
+<ItemGroup>
+  <!-- macOS platform -->
+  <PackageReference Include="Platform.Maui.MacOS" Version="*" />
+  <PackageReference Include="Platform.Maui.MacOS.BlazorWebView" Version="*" />  <!-- Blazor only -->
+  <PackageReference Include="Platform.Maui.Essentials.MacOS" Version="*" />
+
+  <!-- MAUI DevFlow (standard packages — they include net10.0-macos support) -->
+  <PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="*" />
+  <PackageReference Include="Microsoft.Maui.DevFlow.Blazor" Version="*" />  <!-- Blazor only -->
+</ItemGroup>
+```
+
+The standard `Microsoft.Maui.DevFlow.Agent` and `Microsoft.Maui.DevFlow.Blazor` packages include
+`net10.0-macos` targets — no separate macOS-specific MAUI DevFlow packages needed.
+
+## Registration
+
+### Program.cs (Entry Point)
+
+```csharp
+using AppKit;
+using Microsoft.Maui.Platform.MacOS;
+using ObjCRuntime;
+
+namespace MyApp.MacOS;
+
+[Register("Program")]
+public class Program : MacOSMauiApplication
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+    static void Main(string[] args)
+    {
+        NSApplication.Init();
+        NSApplication.Main(args);
+    }
+}
+```
+
+The `[Register]` attribute is required.
+
+### MauiProgram.cs
+
+```csharp
+using Microsoft.Maui.Platform.MacOS;
+using Microsoft.Maui.Platform.MacOS.Controls;
+
+#if DEBUG
+using Microsoft.Maui.DevFlow.Agent;
+using Microsoft.Maui.DevFlow.Blazor;
+#endif
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiAppMacOS<App>()    // NOT UseMauiApp — macOS-specific
+            .AddMacOSEssentials()       // REQUIRED — without this, no window appears
+            .AddMacOSBlazorWebView()    // Blazor only
+            .ConfigureFonts(fonts => { /* ... */ });
+
+#if DEBUG
+        builder.AddMauiDevFlowAgent();
+        builder.AddMauiBlazorDevFlowTools();  // Blazor only
+#endif
+
+        return builder.Build();
+    }
+}
+```
+
+**Critical:** `AddMacOSEssentials()` is required — without it the app runs but no window appears.
+
+## Building and Running
+
+macOS apps do NOT use `-t:Run`. Build first, then launch with `open`:
+
+```bash
+# Build
+dotnet build -f net10.0-macos path/to/MyApp.MacOS
+
+# Find and launch the .app bundle
+open path/to/MyApp.MacOS/bin/Debug/net10.0-macos/osx-arm64/AppName.app
+```
+
+**Code signing:** A clean `dotnet build` produces a valid ad-hoc signature. Do NOT manually
+re-sign the app — it breaks the signature (SIGKILL on launch). If the app fails to launch,
+clean rebuild: `rm -rf bin obj && dotnet build`.
+
+**Finding the .app bundle:**
+```bash
+find bin/Debug/net10.0-macos -name "*.app" -maxdepth 3
+```
+
+## Network Setup
+
+**No special setup needed.** macOS apps run directly on localhost — the CLI connects
+directly to `http://localhost:<port>`. No port forwarding or entitlements required.
+
+## Blazor Hybrid
+
+Use `MacOSBlazorWebView` instead of the standard `BlazorWebView`:
+
+```csharp
+using Microsoft.Maui.Platform.MacOS.Controls;
+
+// In page code-behind, replace BlazorWebView with MacOSBlazorWebView
+var blazorWebView = new MacOSBlazorWebView();
+blazorWebView.HostPage = "wwwroot/index.html";
+blazorWebView.RootComponents.Add(new RootComponent { ... });
+```
+
+Chobitsu.js is auto-injected via the Blazor JS module initializer — no manual `<script>` tag needed.
+
+## Platform Differences
+
+| Feature | Mac Catalyst | macOS (AppKit) |
+|---------|-------------|----------------|
+| TFM | `net10.0-maccatalyst` | `net10.0-macos` |
+| Base framework | UIKit via Catalyst | AppKit |
+| Packages | Standard MAUI | Platform.Maui.MacOS |
+| Project structure | Standard MAUI single-project | Separate app head project |
+| Build + Run | `dotnet build -t:Run` | `dotnet build` then `open App.app` |
+| Entry point | Standard MAUI | `MacOSMauiApplication` with `[Register]` |
+| Builder | `UseMauiApp<App>()` | `UseMauiAppMacOS<App>()` |
+| Essentials | Built-in | `AddMacOSEssentials()` (required) |
+| BlazorWebView | Standard `BlazorWebView` | `MacOSBlazorWebView` |
+| Entitlements | Required (`network.server`) | Not needed |
+| Native sidebar | N/A | `MacOSShell.SetUseNativeSidebar(shell, true)` |
+
+## Troubleshooting
+
+### App Launches But No Window Appears
+**Cause:** Missing `AddMacOSEssentials()` call in MauiProgram.cs.
+**Fix:** Add `.AddMacOSEssentials()` to the builder chain.
+
+### SIGKILL on Launch (Code Signature Invalid)
+**Cause:** Manually re-signing the app bundle or corrupted build artifacts.
+**Fix:** Clean rebuild: `rm -rf bin obj && dotnet build -f net10.0-macos`.
+Never use `codesign` manually — the build produces a valid ad-hoc signature.
+
+### Blazor Page Shows "Loading..." Indefinitely
+**Cause:** Using standard `BlazorWebView` instead of `MacOSBlazorWebView`.
+**Fix:** Replace `BlazorWebView` with `MacOSBlazorWebView` from `Microsoft.Maui.Platform.MacOS.Controls`.
+
+### No Shell Sidebar Content
+**Cause:** macOS Shell needs explicit native sidebar configuration.
+**Fix:** In AppShell code-behind:
+```csharp
+FlyoutBehavior = FlyoutBehavior.Locked;
+MacOSShell.SetUseNativeSidebar(this, true);
+```
+
+### Agent Not Connecting
+1. Ensure the app launched successfully (window appeared)
+2. Check `maui devflow list` — agent should register within a few seconds
+3. If using an older build, clean and rebuild to pick up latest agent code

--- a/.claude/skills/maui-devflow-debug/references/setup.md
+++ b/.claude/skills/maui-devflow-debug/references/setup.md
@@ -1,0 +1,350 @@
+# Setup & Installation
+
+Complete guide for integrating MAUI DevFlow into a .NET MAUI app.
+
+## Table of Contents
+- [Install CLI Tools](#1-install-cli-tools)
+- [Add NuGet Packages](#2-add-nuget-packages)
+- [Register in MauiProgram.cs](#3-register-in-mauiprogramcs)
+- [Port Configuration](#3b-port-configuration)
+- [Blazor Hybrid Setup](#4-blazor-hybrid-chobitsu-auto-injection)
+- [Mac Catalyst Entitlements](#5-mac-catalyst-entitlements)
+- [Android Port Forwarding](#6-android-port-forwarding)
+- [Verify Setup](#7-verify-setup)
+- [Checking for Updates](#checking-for-updates)
+
+## 1. Install CLI Tools
+
+```bash
+dotnet tool install --global Microsoft.Maui.Cli --prerelease
+dotnet tool install --global androidsdk.tool               # android (Android only)
+dotnet tool install --global appledev.tools                # apple (iOS/Mac only)
+```
+
+Verify: `maui devflow version`
+
+## 2. Add NuGet Packages
+
+First, determine whether the project is a standard MAUI app or a Linux/GTK app.
+There is no `-linux` TFM — Linux/GTK apps target plain `net10.0` (or `net9.0`) and use
+the community `Maui.Gtk` package. Detect this by checking the `.csproj`:
+
+```bash
+# Check for GTK indicators in the project
+grep -i 'GirCore\|Maui\.Gtk\|Gtk-4\.0' *.csproj Directory.Build.props 2>/dev/null
+```
+
+If GTK/GirCore references are found, use the **Linux/GTK packages** below.
+Otherwise, use the **standard MAUI packages**.
+
+### Standard MAUI Apps (iOS, Android, Mac Catalyst, Windows, macOS)
+
+Add to your MAUI app's `.csproj`:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="*" />
+  <!-- Blazor Hybrid apps also need: -->
+  <PackageReference Include="Microsoft.Maui.DevFlow.Blazor" Version="*" />
+</ItemGroup>
+```
+
+- `Microsoft.Maui.DevFlow.Agent` — Required for all MAUI apps (iOS, Android, Mac Catalyst, Windows, macOS AppKit). Provides the in-app agent
+  for visual tree inspection, screenshots, tapping, filling text, etc.
+- `Microsoft.Maui.DevFlow.Blazor` — Required for Blazor Hybrid apps. Provides the CDP bridge
+  for DOM inspection, JavaScript evaluation, and Blazor debugging.
+
+**macOS (AppKit) apps** also need the `Platform.Maui.MacOS` packages — see [references/macos.md](macos.md)
+for the full project setup including entry point, builder configuration, and BlazorWebView differences.
+
+### Linux/GTK Apps
+
+Linux/GTK apps (using Maui.Gtk) use separate packages:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.Maui.DevFlow.Agent.Gtk" Version="*" />
+  <!-- Blazor Hybrid apps also need: -->
+  <PackageReference Include="Microsoft.Maui.DevFlow.Blazor.Gtk" Version="*" />
+</ItemGroup>
+```
+
+- `Microsoft.Maui.DevFlow.Agent.Gtk` — Agent for Linux/GTK apps. Uses GirCore.Gtk-4.0 for native GTK integration.
+- `Microsoft.Maui.DevFlow.Blazor.Gtk` — CDP bridge for WebKitGTK-based BlazorWebView on Linux.
+
+## 3. Register in MauiProgram.cs
+
+```csharp
+using Microsoft.Maui.DevFlow.Agent;
+using Microsoft.Maui.DevFlow.Blazor;  // Blazor Hybrid only
+
+var builder = MauiApp.CreateBuilder();
+// ... your existing setup ...
+
+#if DEBUG
+builder.Services.AddBlazorWebViewDeveloperTools();          // Blazor Hybrid only
+builder.AddMauiDevFlowAgent();
+builder.AddMauiBlazorDevFlowTools(); // Blazor Hybrid only
+#endif
+```
+
+### Linux/GTK Registration
+
+For Linux/GTK apps, use the GTK-specific namespaces and add the agent startup call:
+
+```csharp
+using Microsoft.Maui.DevFlow.Agent.Gtk;
+using Microsoft.Maui.DevFlow.Blazor.Gtk;  // Blazor Hybrid only
+
+var builder = MauiApp.CreateBuilder();
+// ... your existing setup ...
+
+#if DEBUG
+builder.AddMauiDevFlowAgent();
+builder.AddMauiBlazorDevFlowTools(); // Blazor Hybrid only
+#endif
+```
+
+After the MAUI app is activated (e.g., in `OnActivate` or after `Application.Current` is available):
+
+```csharp
+#if DEBUG
+app.StartDevFlowAgent();
+// For Blazor, wire CDP to agent:
+var blazorService = app.Handler?.MauiContext?.Services.GetService<GtkBlazorWebViewDebugService>();
+blazorService?.WireBlazorCdpToAgent();
+#endif
+```
+
+**Agent options:**
+- `Port` — HTTP port for the agent REST API (default: 9223). Also configurable via `.mauidevflow` or `-p:MauiDevFlowPort=XXXX`.
+- `Enabled` — Enable/disable the agent (default: true)
+- `MaxTreeDepth` — Max depth for visual tree queries, 0 = unlimited (default: 0)
+
+## 3b. Port Configuration
+
+**Automatic (via broker):** The CLI includes a broker daemon that automatically assigns
+ports to agents. No manual port configuration is needed — the broker handles it. The CLI
+auto-starts the broker on first use. See the main SKILL.md for details on the broker.
+
+**Manual fallback (.mauidevflow):** If the broker isn't available, create a `.mauidevflow`
+file in the project directory to set an explicit port:
+
+```json
+{
+  "port": 9347
+}
+```
+
+Both the MSBuild targets and the CLI read this file automatically:
+- **Build**: `dotnet build -t:Run` — agent starts on the configured port
+- **CLI**: `maui devflow ui status` — connects to the configured port (when run from project dir)
+
+**Port priority:** Explicit `--agent-port` > Broker discovery > `.mauidevflow` > default 9223.
+
+**How port discovery works:** When you run any `MAUI` or `cdp` command, the CLI:
+1. Auto-starts the broker if not running
+2. Queries the broker for agents matching the current project (`.csproj` in cwd)
+3. If one agent matches → uses its port automatically
+4. If multiple match → prints a disambiguation table to stderr
+5. Falls back to `.mauidevflow` config file → default 9223
+
+**Multiple apps simultaneously:** The broker assigns unique ports from range 10223–10899.
+Use `maui devflow list` to see all agents, then target a specific one:
+```bash
+maui devflow ui status --agent-port 10224    # target specific agent
+```
+
+**Blazor options:**
+- `Enabled` — Enable/disable CDP support (default: true)
+- `EnableWebViewInspection` — Enable WebView inspection (default: true)
+- `EnableLogging` — Log debug messages (default: true in DEBUG)
+
+## 4. Blazor Hybrid: Chobitsu Auto-Injection
+
+**No manual setup needed for Blazor Hybrid apps.** The `Microsoft.Maui.DevFlow.Blazor` NuGet package
+automatically injects `chobitsu.js` (the CDP implementation) via a Blazor JS initializer.
+Just add the NuGet package and register in `MauiProgram.cs` — that's it.
+
+### Fallback: Manual Script Tag
+
+If auto-injection doesn't work in your setup (e.g., older .NET versions), add this line
+before `</body>` in `wwwroot/index.html`:
+
+```html
+<script src="chobitsu.js"></script>
+```
+
+The library detects both approaches — manual script tags take priority over auto-injection.
+
+### What if it's not working?
+
+The library checks at runtime and logs a message:
+```
+[BlazorDevFlow] ⚠️ No chobitsu script tag found. Auto-injection via JS initializer may not have run.
+```
+
+### How the file gets there
+
+The `chobitsu.js` file is included in the NuGet package as a static web asset. It is
+automatically available at the root of your app's `wwwroot/` — no `.targets` file copying,
+no manual downloads. It works in both Debug and Release builds (though MAUI DevFlow itself
+should only be referenced in Debug configurations).
+
+## 5. Mac Catalyst: Entitlements
+
+Mac Catalyst apps need the `com.apple.security.network.server` entitlement to allow the
+agent and CDP servers to bind ports. Without this, the app will crash or fail silently.
+
+### Option A: Sandbox disabled (simpler for development)
+
+Create or update `Platforms/MacCatalyst/Entitlements.plist` for Debug builds:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+  </dict>
+</plist>
+```
+
+### Option B: Sandbox enabled (required for App Store)
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+  </dict>
+</plist>
+```
+
+Reference in your `.csproj` (Debug only, so Release uses the default entitlements):
+
+```xml
+<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))
+    == 'maccatalyst' and '$(Configuration)' == 'Debug'">
+  <CodeSignEntitlements>Platforms/MacCatalyst/Entitlements.Debug.plist</CodeSignEntitlements>
+</PropertyGroup>
+```
+
+**Avoiding TCC permission dialogs:** Even with sandbox disabled, macOS prompts for access to
+`~/Documents`, `~/Downloads`, `~/Desktop`, and dotfiles in `~/` on every rebuild (ad-hoc signing
+changes the code signature each build). To avoid this, store app data in
+`Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)` (`~/Library/Application Support/`)
+instead of the home directory root. This path is not TCC-protected.
+
+## 6. Android: Port Forwarding
+
+After deploying to an Android emulator, set up port forwarding for the broker and agent:
+
+```bash
+adb reverse tcp:19223 tcp:19223  # Broker (lets agent register with host broker)
+adb forward tcp:<port> tcp:<port> # Agent (lets CLI reach agent — get port from `maui devflow list`)
+```
+
+The broker reverse (`tcp:19223`) is needed so the agent inside the emulator can connect to
+the host's broker daemon. Set this up once per emulator session.
+
+The agent forward uses the port shown in `maui devflow list` after the agent registers
+(range 10223–10899).
+
+**Fallback (no broker):** If using direct mode with a `.mauidevflow` config file:
+```bash
+adb forward tcp:9223 tcp:9223    # Direct agent port (single port for Agent + CDP)
+```
+
+## 7. Verify Setup
+
+After building and running the app:
+
+```bash
+maui devflow list                 # Should show registered agents (via broker)
+maui devflow ui status            # Should show agent info, platform, app name
+maui devflow webview status       # Should show "Connected" (Blazor Hybrid only)
+```
+
+If status commands fail:
+- **Broker not running?** `maui devflow broker status` — CLI auto-starts the broker, but check if it's healthy
+- **Agent not registered?** `maui devflow list` — wait a few seconds for the agent to register
+- **Mac Catalyst:** Check entitlements (Step 5)
+- **macOS (AppKit):** Ensure `AddMacOSEssentials()` is called — see [references/macos.md](macos.md)
+- **Android:** Check port forwarding (Step 6) — need both `adb reverse tcp:19223` and `adb forward tcp:<port>`
+- **iOS Simulator:** Should work without extra config
+- **Linux/GTK:** Should work without extra config — runs directly on localhost
+- **All platforms:** Ensure the app is running and the `#if DEBUG` block is active
+- **Port conflict:** Check if another process holds the port: `lsof -i :9223` (or your configured port)
+- **Wrong port:** Use `maui devflow list` to find the assigned port, or ensure CLI is run from the project directory
+
+## Quick Checklist
+
+For an AI agent setting up MAUI DevFlow in a new project:
+
+1. [ ] `Microsoft.Maui.DevFlow.Agent` NuGet package added (or `Microsoft.Maui.DevFlow.Agent.Gtk` for Linux)
+2. [ ] `Microsoft.Maui.DevFlow.Blazor` NuGet package added (Blazor Hybrid only; or `Microsoft.Maui.DevFlow.Blazor.Gtk` for Linux)
+3. [ ] `builder.AddMauiDevFlowAgent(...)` in MauiProgram.cs inside `#if DEBUG`
+4. [ ] `builder.AddMauiBlazorDevFlowTools(...)` in MauiProgram.cs (Blazor Hybrid only)
+5. [ ] Chobitsu auto-injected via JS initializer (Blazor Hybrid — no manual step needed)
+6. [ ] Mac Catalyst entitlements include `network.server` (Mac Catalyst only)
+7. [ ] `adb reverse tcp:19223` for broker + `adb forward tcp:<port>` for agent (Android only)
+8. [ ] Linux/GTK: `app.StartDevFlowAgent()` called after app activation
+9. [ ] macOS (AppKit): `UseMauiAppMacOS()`, `AddMacOSEssentials()`, `MacOSBlazorWebView` — see [macos.md](macos.md)
+10. [ ] Verify with `maui devflow list` and `maui devflow ui status`
+
+## Checking for Updates
+
+At the start of each session (or periodically), check whether the CLI, skill, and NuGet
+packages are up to date. Outdated components can cause confusing failures or missing features.
+
+### Check CLI version
+```bash
+maui devflow version
+dotnet tool search Microsoft.Maui.Cli | head -5
+```
+
+If a newer version is available:
+```bash
+dotnet tool update --global Microsoft.Maui.Cli
+```
+
+### Update the skill
+```bash
+maui devflow skills check
+maui devflow skills update
+```
+
+The skills manager compares installed files against the skills bundled in the running
+`Microsoft.Maui.Cli` and records local install state under `~/.maui/devflow`.
+
+**AI agents should check at session start:** run `maui devflow skills check`. If it reports
+`update-available-from-current-cli`, ask the user if they want to run
+`maui devflow skills update` before proceeding.
+
+### Check NuGet packages in the project
+```bash
+grep -i 'Microsoft.Maui.DevFlow' *.csproj Directory.Build.props Directory.Packages.props 2>/dev/null
+```
+
+If packages are outdated:
+```bash
+dotnet add package Microsoft.Maui.DevFlow.Agent
+dotnet add package Microsoft.Maui.DevFlow.Blazor    # only if Blazor Hybrid
+# For Linux/GTK: use .Gtk variants instead
+```
+
+### Re-run setup verification
+After any updates, walk through the checklist above to ensure everything is still properly
+configured. A CLI update may introduce new setup requirements.

--- a/.claude/skills/maui-devflow-debug/references/troubleshooting.md
+++ b/.claude/skills/maui-devflow-debug/references/troubleshooting.md
@@ -1,0 +1,93 @@
+# Troubleshooting
+
+## Table of Contents
+- [Connection Refused](#connection-refused--cannot-connect)
+- [Build Failures](#build-failures)
+- [CDP Not Connecting](#cdp-not-connecting-blazor-hybrid)
+- [Mac Catalyst Permission Dialogs](#mac-catalyst-repeated-permission-dialogs-on-rebuild)
+
+## Connection Refused / Cannot Connect
+
+If `maui devflow ui status` fails with connection refused:
+
+1. **App not running?** Verify the app launched: check the build output for errors.
+2. **Check the broker:** Run `maui devflow list` to see if the agent registered. If the list
+   is empty, the app may not have connected to the broker yet (wait a few seconds and retry).
+3. **Wrong port?** If using `.mauidevflow`, ensure the port matches between build and CLI.
+   Run CLI from the project directory so it auto-detects the config file.
+4. **Port already in use?** Another process may hold the port. Check with:
+   ```bash
+   lsof -i :<port>       # macOS/Linux
+   ```
+   With the broker, this is less common since ports are auto-assigned.
+5. **Android?** Did you run `adb reverse tcp:19223 tcp:19223` (for broker) and
+   `adb forward tcp:<port> tcp:<port>` (for agent)? Re-run after each deploy.
+6. **Mac Catalyst?** Check entitlements include `network.server` (see setup.md step 5).
+7. **macOS (AppKit)?** Ensure `AddMacOSEssentials()` is called and the app window appeared.
+   See [references/macos.md](macos.md) for troubleshooting.
+8. **Linux/GTK?** No special network setup needed — runs directly on localhost. Check if the app started successfully.
+9. **Broker issues?** `maui devflow broker status` to check. `maui devflow broker stop` then
+   retry (CLI will auto-restart it).
+
+## Build Failures
+
+**Missing workloads:**
+```
+error NETSDK1147: To build this project, the following workloads must be installed: maui-ios
+```
+Fix: `dotnet workload install maui` (installs all MAUI workloads).
+
+**SDK version mismatch:**
+```
+error : The current .NET SDK does not support targeting .NET 10.0
+```
+Fix: Install the required .NET SDK version, or check `global.json` for version pins.
+
+**Android SDK not found:**
+```
+error XA0000: Could not find Android SDK
+```
+Fix: Install Android SDK via `android sdk install` or set `$ANDROID_HOME`.
+
+**iOS provisioning / signing errors:**
+Fix: For simulators, ensure no signing is configured (default). For devices, set up provisioning
+profiles via `apple appstoreconnect profiles list`.
+
+**General build failure recovery:**
+1. `dotnet clean` then retry the build
+2. Delete `bin/` and `obj/` directories: `rm -rf bin obj` then rebuild
+3. Check the full build output (not just the last error) — earlier warnings often reveal the root cause
+
+## CDP Not Connecting (Blazor Hybrid)
+
+If `maui devflow webview status` fails but `ui status` works:
+
+1. **Chobitsu not loading?** Check logs for `[BlazorDevFlow]` messages. If auto-injection failed, add `<script src="chobitsu.js"></script>` manually to `wwwroot/index.html`
+2. **Blazor not initialized?** Navigate to a Blazor page first, then retry
+3. Check app logs: `maui devflow ui logs --limit 20` — look for `[BlazorDevFlow]` errors
+
+## Mac Catalyst: Repeated Permission Dialogs on Rebuild
+
+If macOS prompts "App would like to access your Documents folder" on every rebuild:
+
+**Cause:** TCC permissions are tied to the app's code signature. Ad-hoc Debug builds produce a
+different signature each rebuild → macOS forgets the grant and re-prompts. This happens even
+with App Sandbox disabled.
+
+**Fix:** Don't access TCC-protected directories (`~/Documents`, `~/Downloads`, `~/Desktop`,
+or dotfiles like `~/.myapp/` in the home root) programmatically. Instead use:
+- `Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)` → `~/Library/Application Support/` (not TCC-protected)
+- `NSOpenPanel`/`NSSavePanel` for user-initiated file access (grants automatic TCC exemption)
+
+If you can't avoid TCC paths, sign Debug builds with a stable Apple Development certificate
+so the code signature stays consistent across rebuilds.
+
+## macOS (AppKit) Issues
+
+For detailed macOS (AppKit) troubleshooting, see [references/macos.md](macos.md#troubleshooting).
+
+Common issues:
+- **No window appears** → Missing `AddMacOSEssentials()` in builder
+- **SIGKILL on launch** → Don't re-sign manually; clean rebuild instead
+- **Blazor stuck on "Loading..."** → Use `MacOSBlazorWebView`, not standard `BlazorWebView`
+- **No sidebar content** → Add `MacOSShell.SetUseNativeSidebar(shell, true)` + `FlyoutBehavior.Locked`

--- a/.claude/skills/maui-devflow-onboard/SKILL.md
+++ b/.claude/skills/maui-devflow-onboard/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: maui-devflow-onboard
+description: >-
+  Add MAUI DevFlow to a .NET MAUI project with agent package references,
+  MauiProgram.cs registration, Blazor WebView support, GTK variants, Central
+  Package Management guidance, and verification commands. USE FOR: first-time
+  DevFlow setup, reviewing what files to edit, choosing DevFlow packages, or
+  continuing after `maui devflow init` installs skills. DO NOT USE FOR:
+  troubleshooting an already-integrated app that cannot connect, iterative app
+  debugging, UI inspection, or generic MAUI build failures (use
+  maui-devflow-debug). INVOKES: maui devflow CLI and dotnet CLI.
+---
+
+# DevFlow Onboard
+
+Use this skill to add MAUI DevFlow to a project after `maui devflow init` has installed the DevFlow skills.
+
+## When to Use
+
+- The project has no `Microsoft.Maui.DevFlow.*` package references yet.
+- The user asks how to onboard, initialize, install, integrate, or set up DevFlow.
+- The agent needs to choose between standard, Blazor, GTK, or GTK + Blazor DevFlow packages.
+- The repo uses Central Package Management and package edits need to be split correctly.
+- `maui devflow init` has installed skills and the user asks for the next project edits.
+
+## Route Elsewhere
+
+- If package references and `AddMauiDevFlowAgent()` are already present but the CLI cannot connect, use `maui-devflow-debug`.
+- If an agent is reachable and the user wants to inspect, tap, screenshot, or debug UI, use `maui-devflow-debug`.
+
+## Workflow
+
+1. Optionally run `maui devflow skills check` and update bundled skills before editing if it reports `update-available-from-current-cli`.
+2. Find MAUI app projects in the workspace. Prefer app projects with `UseMaui`, platform TFMs such as `net*-android`/`net*-ios`/`net*-maccatalyst`/`net*-windows`, or GTK MAUI package references.
+3. Determine whether each target project is standard MAUI, MAUI + Blazor WebView, GTK, or GTK + Blazor.
+4. Add the correct DevFlow package references. Respect Central Package Management if `Directory.Packages.props` is present.
+5. Register DevFlow in `MauiProgram.cs` inside `#if DEBUG`.
+6. Build and run the app.
+7. Verify with:
+
+   ```bash
+   maui devflow diagnose
+   maui devflow wait
+   maui devflow ui tree --depth 1
+   ```
+
+If verification fails after integration, switch to `maui-devflow-debug` for connectivity recovery.
+
+## Stop Signals
+
+- Stop before editing if multiple MAUI app projects exist and the user has not indicated which one to onboard.
+- Stop and ask before enabling DevFlow outside Debug builds.
+- Stop after package/registration edits and verify with a build before doing runtime debugging.
+
+## Critical Anti-patterns
+
+- Do not add versions to project `PackageReference` items when `Directory.Packages.props` is managing package versions.
+- Do not add Blazor DevFlow packages unless the app uses Blazor WebView.
+- Do not register DevFlow outside `#if DEBUG` unless the user explicitly asks.
+- Do not use the old `builder.Services.AddMauiDevFlowAgent()` pattern; use `builder.AddMauiDevFlowAgent()`.
+
+## Package Selection
+
+| Project flavor | Required packages |
+| --- | --- |
+| Standard MAUI | `Microsoft.Maui.DevFlow.Agent` |
+| MAUI + Blazor WebView | `Microsoft.Maui.DevFlow.Agent`, `Microsoft.Maui.DevFlow.Blazor` |
+| GTK MAUI | `Microsoft.Maui.DevFlow.Agent.Gtk` |
+| GTK MAUI + Blazor WebView | `Microsoft.Maui.DevFlow.Agent.Gtk`, `Microsoft.Maui.DevFlow.Blazor.Gtk` |
+
+Blazor WebView indicators include a `Microsoft.AspNetCore.Components.WebView.Maui` package reference or `AddMauiBlazorWebView()` in `MauiProgram.cs`.
+
+GTK indicators include package references such as `Maui.Gtk`, `Platform.Maui.Linux.Gtk4`, `GirCore.Gtk-4.0`, or `Platform.Maui.Linux.Gtk4.BlazorWebView`.
+
+## Central Package Management
+
+If the repo uses `Directory.Packages.props`, put versions there and leave project `PackageReference` entries versionless.
+
+```xml
+<!-- Directory.Packages.props -->
+<PackageVersion Include="Microsoft.Maui.DevFlow.Agent" Version="<current-version>" />
+```
+
+```xml
+<!-- App.csproj -->
+<PackageReference Include="Microsoft.Maui.DevFlow.Agent" />
+```
+
+If the repo does not use Central Package Management, put the version on the `PackageReference`.
+
+## MauiProgram.cs Registration
+
+For standard MAUI:
+
+```csharp
+using Microsoft.Maui.DevFlow.Agent;
+
+// inside CreateMauiApp(), before return builder.Build();
+#if DEBUG
+builder.AddMauiDevFlowAgent();
+#endif
+```
+
+For MAUI + Blazor WebView:
+
+```csharp
+using Microsoft.Maui.DevFlow.Agent;
+using Microsoft.Maui.DevFlow.Blazor;
+
+// inside CreateMauiApp(), before return builder.Build();
+#if DEBUG
+builder.AddMauiDevFlowAgent();
+builder.AddMauiBlazorDevFlowTools();
+#endif
+```
+
+For GTK, use the `.Gtk` namespaces and packages. GTK apps also need to start the agent after app activation, for example `app.StartDevFlowAgent()` in the platform app activation flow.
+
+For Mac Catalyst, ensure the Debug entitlements allow the in-app HTTP server:
+
+```xml
+<key>com.apple.security.network.server</key>
+<true/>
+```
+
+## Validation Checklist
+
+- `MauiProgram.cs` registers DevFlow only in Debug builds.
+- The app project references the package flavor that matches the target platform.
+- Blazor DevFlow tools are added only when the app uses Blazor WebView.
+- GTK apps start the DevFlow agent after app activation.
+- Mac Catalyst Debug entitlements include `com.apple.security.network.server`.
+- `dotnet build` succeeds.
+- A running app appears in `maui devflow list`.
+- `maui devflow ui tree --depth 1` returns a visual tree.
+
+## References
+
+- See `references/package-selection.md` for package/flavor details.
+- See `references/mauiprogram-registration.md` for registration patterns.

--- a/.claude/skills/maui-devflow-onboard/references/mauiprogram-registration.md
+++ b/.claude/skills/maui-devflow-onboard/references/mauiprogram-registration.md
@@ -1,0 +1,34 @@
+# MauiProgram.cs Registration
+
+Add DevFlow registration in `CreateMauiApp()` before `return builder.Build();`.
+
+Standard MAUI:
+
+```csharp
+using Microsoft.Maui.DevFlow.Agent;
+
+#if DEBUG
+builder.AddMauiDevFlowAgent();
+#endif
+```
+
+MAUI + Blazor WebView:
+
+```csharp
+using Microsoft.Maui.DevFlow.Agent;
+using Microsoft.Maui.DevFlow.Blazor;
+
+#if DEBUG
+builder.AddMauiDevFlowAgent();
+builder.AddMauiBlazorDevFlowTools();
+#endif
+```
+
+GTK uses the `.Gtk` namespaces:
+
+```csharp
+using Microsoft.Maui.DevFlow.Agent.Gtk;
+using Microsoft.Maui.DevFlow.Blazor.Gtk;
+```
+
+Keep the calls inside `#if DEBUG` unless the user explicitly wants DevFlow available in non-Debug builds.

--- a/.claude/skills/maui-devflow-onboard/references/package-selection.md
+++ b/.claude/skills/maui-devflow-onboard/references/package-selection.md
@@ -1,0 +1,23 @@
+# Package Selection
+
+Choose packages based on the app flavor:
+
+| Project flavor | Packages |
+| --- | --- |
+| Standard MAUI | `Microsoft.Maui.DevFlow.Agent` |
+| MAUI + Blazor WebView | `Microsoft.Maui.DevFlow.Agent`, `Microsoft.Maui.DevFlow.Blazor` |
+| GTK MAUI | `Microsoft.Maui.DevFlow.Agent.Gtk` |
+| GTK MAUI + Blazor WebView | `Microsoft.Maui.DevFlow.Agent.Gtk`, `Microsoft.Maui.DevFlow.Blazor.Gtk` |
+
+MAUI indicators:
+
+- `<UseMaui>true</UseMaui>`;
+- platform TFMs such as `net10.0-android`, `net10.0-ios`, `net10.0-maccatalyst`, or `net10.0-windows10.0.19041.0`;
+- GTK package references such as `Maui.Gtk`, `Platform.Maui.Linux.Gtk4`, or `GirCore.Gtk-4.0`.
+
+Blazor WebView indicators:
+
+- package reference to `Microsoft.AspNetCore.Components.WebView.Maui`;
+- call to `AddMauiBlazorWebView()` in `MauiProgram.cs`.
+
+Use Central Package Management if `Directory.Packages.props` exists. Otherwise place versions directly on project package references.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,17 +10,18 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.20" />
+    <PackageVersion Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.8.26256.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <PackageVersion Include="Xamarin.GooglePlayServices.Ads.Identifier" Version="118.2.0.3" />
     <PackageVersion Include="Xamarin.GooglePlayServices.Auth.Blockstore" Version="116.4.0.6" />
     <PackageVersion Include="Xamarin.KotlinX.Serialization.Json" Version="1.8.1" />
-    <PackageVersion Include="Xamarin.Android.Google.BillingClient" Version="8.0.0" />
-    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.9.2.1" />
-    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.9.2.1" />
-    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.9.2.1" />
-    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.9.2.1" />
+    <PackageVersion Include="Xamarin.Android.Google.BillingClient" Version="8.3.0.2" />
+    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.10.0.2" />
+    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.10.0.2" />
+    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.10.0.2" />
+    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.10.0.2" />
     <PackageVersion Include="Xamarin.Kotlin.Parcelize.Runtime" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/android/RevenueCat.Android.Binding/RevenueCat.Android.Binding.csproj
+++ b/android/RevenueCat.Android.Binding/RevenueCat.Android.Binding.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<RevenueCatSdkVersion>9.19.1</RevenueCatSdkVersion>
+		<RevenueCatSdkVersion>10.5.0</RevenueCatSdkVersion>
 		<RevenueCatSdkUrl>https://repo1.maven.org/maven2/com/revenuecat/purchases/purchases/$(RevenueCatSdkVersion)/purchases-$(RevenueCatSdkVersion).aar</RevenueCatSdkUrl>
 		<RevenueCatUISdkUrl>https://repo1.maven.org/maven2/com/revenuecat/purchases/purchases-ui/$(RevenueCatSdkVersion)/purchases-ui-$(RevenueCatSdkVersion).aar</RevenueCatUISdkUrl>
 	</PropertyGroup>

--- a/android/native/revenuecatbinding/build.gradle.kts
+++ b/android/native/revenuecatbinding/build.gradle.kts
@@ -31,11 +31,10 @@ dependencies {
     // Uncomment line below and replace {dependency.name.goes.here} with your dependency
     // implementation("{dependency.name.goes.here}")
 
-    implementation("com.revenuecat.purchases:purchases:9.19.1")
-    implementation("com.revenuecat.purchases:purchases-store-amazon:9.19.1")
+    implementation("com.revenuecat.purchases:purchases:10.5.0")
+    implementation("com.revenuecat.purchases:purchases-store-amazon:10.5.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3")
 //    implementation("com.revenuecat.purchases:purchases-ui:8.16.0")
     implementation("com.google.code.gson:gson:2.12.0")
 
 }
-

--- a/macios/RevenueCat.MaciOS.Binding/RevenueCat.MaciOS.Binding.csproj
+++ b/macios/RevenueCat.MaciOS.Binding/RevenueCat.MaciOS.Binding.csproj
@@ -31,7 +31,7 @@
 			-->
 		</XcodeProject>
 
-		<NativeReference Include="../native/bin/deps/RevenueCat/RevenueCat.xcframework">
+		<NativeReference Include="../native/bin/deps/RevenueCat.xcframework">
 			<Kind>Framework</Kind>
 			<SmartLink>true</SmartLink>
 			<ForceLoad>true</ForceLoad>
@@ -121,13 +121,13 @@
 	
 	<Target Name="DownloadNativeDependencies" BeforeTargets="Build" Condition=" '$(IsCrossTargetingBuild)' == 'true' ">
 		<PropertyGroup>
-			<RevenueCatSdkVersion>5.55.2</RevenueCatSdkVersion>
+			<RevenueCatSdkVersion>5.72.0</RevenueCatSdkVersion>
 
 			<RevenueCatSdkUrl>https://github.com/RevenueCat/purchases-ios/releases/download/$(RevenueCatSdkVersion)/RevenueCat.xcframework.zip</RevenueCatSdkUrl>
 			
 			<_RevenueCatDownloadPath>$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)))/../native/bin/deps</_RevenueCatDownloadPath>
-			<_RevenueCatFrameworkPListFilePath>$(_RevenueCatDownloadPath)/RevenueCat/RevenueCat.xcframework/Info.plist</_RevenueCatFrameworkPListFilePath>
-			<_RevenueCatXcFrameworkPath>$(_RevenueCatDownloadPath)/RevenueCat/RevenueCat.xcframework</_RevenueCatXcFrameworkPath>
+			<_RevenueCatFrameworkPListFilePath>$(_RevenueCatDownloadPath)/RevenueCat.xcframework/Info.plist</_RevenueCatFrameworkPListFilePath>
+			<_RevenueCatXcFrameworkPath>$(_RevenueCatDownloadPath)/RevenueCat.xcframework</_RevenueCatXcFrameworkPath>
 		</PropertyGroup>
 
 		<DownloadFile SourceUrl="$(RevenueCatSdkUrl)" DestinationFolder="$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)/../native/bin/deps))">
@@ -144,7 +144,7 @@
 			<_RevenueCatUnwantedPlatforms Include="watchos-arm64_i386_x86_64-simulator" />
 		</ItemGroup>
 		
-		<Exec Command="codesign --deep --remove-signature $(_RevenueCatDownloadPath)/RevenueCat/RevenueCat.xcframework" />
+		<Exec Command="codesign --deep --remove-signature $(_RevenueCatXcFrameworkPath)" />
 		
 		<!-- Remove vision and watchos to save space -->
 		<RemoveDir Directories="$(_RevenueCatXcFrameworkPath)/%(_RevenueCatUnwantedPlatforms.Identity)" />

--- a/macios/native/RevenueCatBinding/RevenueCatBinding.xcodeproj/project.pbxproj
+++ b/macios/native/RevenueCatBinding/RevenueCatBinding.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		646070982D42CC940036C905 /* RevenueCat.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RevenueCat.xcframework; path = ../bin/deps/RevenueCat/RevenueCat.xcframework; sourceTree = "<group>"; };
+		646070982D42CC940036C905 /* RevenueCat.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RevenueCat.xcframework; path = ../bin/deps/RevenueCat.xcframework; sourceTree = "<group>"; };
 		83E34F532C21CB2B008AA950 /* RevenueCatBinding.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RevenueCatBinding.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		83E34F562C21CB2B008AA950 /* RevenueCat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RevenueCat.h; sourceTree = "<group>"; };
 		83E34F5D2C21CC53008AA950 /* RevenueCatBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevenueCatBinding.swift; sourceTree = "<group>"; };

--- a/sample/MauiProgram.cs
+++ b/sample/MauiProgram.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Microsoft.Maui.DevFlow.Agent;
 using Plugin.RevenueCat;
 
 namespace MauiSample;
@@ -23,6 +24,7 @@ public static class MauiProgram
 		builder.Services.AddTransient<MainPage>();
 
 #if DEBUG
+		builder.AddMauiDevFlowAgent();
 		builder.Logging.AddDebug();
 #endif
 

--- a/sample/MauiSample.csproj
+++ b/sample/MauiSample.csproj
@@ -53,6 +53,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" />
+		<PackageReference Include="Microsoft.Maui.DevFlow.Agent" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" />
 	</ItemGroup>
 

--- a/sample/Platforms/MacCatalyst/Entitlements.plist
+++ b/sample/Platforms/MacCatalyst/Entitlements.plist
@@ -9,6 +9,8 @@
         <!-- When App Sandbox is enabled, this value is required to open outgoing network connections. -->
         <key>com.apple.security.network.client</key>
         <true/>
+        <key>com.apple.security.network.server</key>
+        <true/>
     </dict>
 </plist>
 


### PR DESCRIPTION
## Why

This updates the plugin to the latest RevenueCat native SDKs and adds the new MAUI DevFlow setup so the sample app can be launched and inspected with the current `Microsoft.Maui.Cli` preview tooling.

## What changed

- Added the DevFlow onboard/debug skill bundles generated by `maui devflow init` and onboarded the sample with `Microsoft.Maui.DevFlow.Agent`.
- Updated RevenueCat iOS/macCatalyst from `5.55.2` to `5.72.0`, including the new direct `RevenueCat.xcframework` zip layout in both MSBuild and Xcode references.
- Updated RevenueCat Android from `9.19.1` to `10.5.0`, with Google Billing Client `8.3.0.2` and AndroidX Lifecycle package alignment for the new dependency graph.
- Added the Mac Catalyst network server entitlement needed for the DevFlow agent.

## Validation

- Built Android native Gradle AAR.
- Built Android binding project.
- Built iOS/macCatalyst binding project.
- Built and deployed the Android sample to an emulator, confirmed it launched and stayed running without immediate missing-library crashes.
- Connected to the sample through MAUI DevFlow on Android and read a UI tree.
- Built the test project.

## Notes

`dotnet test` still requires local RevenueCat test configuration (`AppSettings:ApiKeyV1`). A full solution build is blocked on this machine only for sample iOS/MacCatalyst because the installed .NET iOS/MacCatalyst workload requires Xcode 26.2 while the machine has Xcode 26.4.1.