### PR TITLE
Carry forward offering fallback and 16 KB guidance

### DIFF
--- a/Plugin.RevenueCat/RevenueCatManager.cs
+++ b/Plugin.RevenueCat/RevenueCatManager.cs
@@ -70,7 +70,10 @@ public class RevenueCatManager : IRevenueCatManager
 		=> Request<CustomerInfo>(nameof(GetCustomerInfoAsync), () => PlatformImplementation.GetCustomerInfoAsync(force));
 	
 	public Task<Offering?> GetOfferingAsync(string offeringIdentifier)
-		=> Request<Offering>(nameof(GetOfferingAsync), () => PlatformImplementation.GetOfferingAsync(offeringIdentifier));
+	{
+		Logger.LogInformation("RevenueCatManager->{Name}: Requesting offering '{OfferingIdentifier}'.", nameof(GetOfferingAsync), offeringIdentifier);
+		return Request<Offering>(nameof(GetOfferingAsync), () => PlatformImplementation.GetOfferingAsync(offeringIdentifier));
+	}
 
 	public Task<CustomerInfo?> RestoreAsync()
 		=> Request<CustomerInfo>(nameof(RestoreAsync), PlatformImplementation.RestoreAsync);
@@ -143,7 +146,14 @@ public class RevenueCatManager : IRevenueCatManager
 	{
 		if (string.IsNullOrEmpty(json))
 		{
-			Logger.LogWarning("RevenueCatManager->{Name}: JSON response is null or empty.", name);
+			if (typeof(TObject) == typeof(Offering))
+			{
+				Logger.LogWarning("RevenueCatManager->{Name}: JSON response is null or empty. Check that the requested offering exists or that a current/default offering is configured in RevenueCat.", name);
+			}
+			else
+			{
+				Logger.LogWarning("RevenueCatManager->{Name}: JSON response is null or empty.", name);
+			}
 			return default;
 		}
 		
@@ -173,4 +183,3 @@ public class RevenueCatManager : IRevenueCatManager
 		return obj;
 	}
 }
-

--- a/README.md
+++ b/README.md
@@ -57,8 +57,18 @@ Use the `IRevenueCatManager` instance (resolved through dependency injection) to
 - `Initialize(...)` - this is called for you if you use the `UseRevenueCat()` builder method and calling it again manually has no effect
 - `Task<CustomerInfoRequest?> LoginAsync(string userId)` once you know the user identifier for your purchases, you should call this.  You should avoid calling it unnecessarily as it can cause multiple user account objects to be created if you do.  You should also try to call it as early in the lifecycle of your app as possible.
 - `Task<CustomerInfoRequest?> GetCustomerInfoAsync(bool force)` Call this to get the latest customer info.  If you use `false` for `force`, you may have a cached instance returned from the method.  Use `true` to force updating from the server.  The `CustomerInfoUpdated` event and any callback you specify in the initialization will also be called with the updated info regardless of the `force` value you set here.
-- `Task<Offering?> GetOfferingAsync(string offeringIdentifier)` Gets the offering (and its packages/products) for a given identifier.  Use this to get the information you need to display to the user when deciding on a purchase, such as the packages, prices, etc.
+- `Task<Offering?> GetOfferingAsync(string offeringIdentifier)` Gets the offering (and its packages/products) for a given identifier.  Use this to get the information you need to display to the user when deciding on a purchase, such as the packages, prices, etc.  If no exact match is found, the platform bindings fall back to the current/default offering when one is configured.
 - `Task<CustomerInfoRequest?> RestoreAsync()` - Restores any purchases and returns the customer info which will have the entitlements relevant to the user.
 - `Task<CustomerInfoRequest?> PurchaseAsync(object? platformContext, string offeringIdentifier, string packageIdentifier)` - Initiates a purchase.  The `platformContext` should be an `Activity` (likely the current one) on Android, and is currently unused on iOS/MacCatalyst.  There's a version of this method you can call which infers the default 'current' activity of your MAUI app automatically.  You also need to pass the `offeringIdentifier` and the `packageIdentifier` the user wants to purchase (if you only have one package, pick the first one).
 - `Task<CustomerInfoRequest?> PurchaseAsync(string offeringIdentifier, string packageIdentifier)` - Same as above, but Initiates a purchase.  The `platformContext` should be an `Activity` (likely the current one) on Android, and is currently unused on iOS/MacCatalyst.  There's a version of this method you can call which infers the default 'current' activity of your MAUI app automatically.  You also need to pass the `offeringIdentifier` and the `packageIdentifier` the user wants to purchase (if you only have one package, pick the first one).
 - `Task<CustomerInfoRequest?> PurchaseAsync(string offeringIdentifier, string packageIdentifier)` - Same as above, but automatically infers the default 'current' activity of your MAUI app automatically.
+
+### Android 15 / 16 KB page-size notes
+
+This binding package does not currently ship native RevenueCat `.so` libraries on Android, so 16 KB Play Console warnings are usually caused by the consuming app's packaged native dependencies or Android build toolchain rather than the RevenueCat wrapper itself.
+
+Current .NET for Android toolchains align Android packages for 16 KB pages by default. If warnings persist in a consuming app, update to a current .NET for Android / .NET MAUI workload, inspect the final APK or AAB, and identify which packaged native library needs an update. For APKs, Android's `zipalign` verification can check shared-library alignment:
+
+```bash
+zipalign -c -P 16 -v 4 path/to/app.apk
+```

--- a/android/native/revenuecatbinding/src/main/java/com/revenuecat/revenuecatbinding/RevenueCatManager.java
+++ b/android/native/revenuecatbinding/src/main/java/com/revenuecat/revenuecatbinding/RevenueCatManager.java
@@ -107,12 +107,24 @@ public class RevenueCatManager
         Purchases.getSharedInstance().getOfferings(new ReceiveOfferingsCallback() {
             @Override
             public void onReceived(@NonNull Offerings offerings) {
-                Offering offering;
+                Offering offering = null;
+                String requestedOffering = offeringIdentifier == null ? "" : offeringIdentifier.trim();
 
-                if (offeringIdentifier != null)
+                if (!requestedOffering.isEmpty()) {
                     offering = offerings.get(offeringIdentifier);
-                else
+                }
+
+                if (offering == null) {
                     offering = offerings.getCurrent();
+                }
+
+                if (offering == null) {
+                    String message = requestedOffering.isEmpty()
+                        ? "No current offering is configured."
+                        : "No offering found for identifier '" + requestedOffering + "' and no current offering is configured.";
+                    future.completeExceptionally(new Exception(message));
+                    return;
+                }
 
                 Map<String, Object> offeringInfo = new HashMap<>();
                 offeringInfo.put("id", offering.getIdentifier());
@@ -342,4 +354,3 @@ public class RevenueCatManager
 		return future;
 	}
 }
-

--- a/macios/native/RevenueCatBinding/RevenueCatBinding/RevenueCatBinding.swift
+++ b/macios/native/RevenueCatBinding/RevenueCatBinding/RevenueCatBinding.swift
@@ -156,7 +156,16 @@ public class RevenueCatManager : NSObject
                 
                 //callback(currentOffering.description as NSString, nil)
             } else {
-                callback(nil, nil)
+                let requestedOffering = offeringId.trimmingCharacters(in: .whitespacesAndNewlines)
+                let message = requestedOffering.isEmpty
+                    ? "No current offering is configured."
+                    : "No offering found for identifier '\(requestedOffering)' and no current offering is configured."
+                let error = NSError(
+                    domain: "RevenueCatManager",
+                    code: 404,
+                    userInfo: [NSLocalizedDescriptionKey: message]
+                )
+                callback(nil, error)
             }
         }
     }


### PR DESCRIPTION
This carries forward the non-version parts of old PR #22 after the newer SDK update superseded the SDK and package bumps. The remaining useful pieces are the Android offering fallback behavior, clearer missing-offering diagnostics, and consumer guidance for Android 16 KB page-size warnings.

## Summary

- Make Android `getOffering` match iOS behavior by falling back to the current/default offering when a requested offering is missing or blank.
- Return explicit native errors when neither the requested offering nor a current offering is configured.
- Add C# logging around requested offering IDs and empty offering responses.
- Document offering fallback semantics and Android 16 KB troubleshooting guidance without copying the older redundant sample alignment setting.

## Validation

- `dotnet build android/RevenueCat.Android.Binding/RevenueCat.Android.Binding.csproj && dotnet build Plugin.RevenueCat/Plugin.RevenueCat.csproj`
- `dotnet build RevenueCat.sln` was blocked only by local sample iOS/MacCatalyst Xcode compatibility: .NET Apple SDK requires Xcode 26.2, local Xcode is 26.4.1. The changed binding/plugin projects built successfully.
- `dotnet test ./Tests/Tests.csproj` was blocked by missing `AppSettings:ApiKeyV1` test configuration.